### PR TITLE
Bug in checking private variables.

### DIFF
--- a/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -277,7 +277,7 @@ class CakePHP_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSn
 		}
         // Check that the name only contains legal characters.
         $legalChars = 'a-zA-Z0-9';
-        if (preg_match("|[^$legalChars]|", substr($string, 1)) > 0) {
+        if (preg_match("|[^$legalChars]|", substr($string, $firstStringCount)) > 0) {
             return false;
         }
         return true;


### PR DESCRIPTION
Private variables require double underscore (__), however the isValidVar does not account for private variables. It only allows for protected  variables with a single underscore. This will resolve the private variable check by changing the number of characters to remove from the beginning of the string before checking legalChars.
