### PR TITLE
Removing sniff for TODO comments

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -18,8 +18,7 @@
  <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
 
  <rule ref="Squiz.Commenting.DocCommentAlignment"/>
- <rule ref="Generic.Commenting.Todo"/>
-
+ 
  <rule ref="PEAR.ControlStructures.ControlSignature"/>
  <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
  <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>


### PR DESCRIPTION
I don't think warnings for TODO comments are really needed since most TODOs are not addressed until next major release. Just creates extra noise in the reports.
