### PR TITLE
adding sniff for space and tab mixing, remove ForceTabIndentSniff using ...

### DIFF
--- a/Sniffs/WhiteSpace/TabAndSpaceSniff.php
+++ b/Sniffs/WhiteSpace/TabAndSpaceSniff.php
@@ -13,8 +13,27 @@
  * @version   Release: 1.0
  * @link      http://pear.php.net/package/PHP_CodeSniffer_CakePHP
  */
-class CakePHP_Sniffs_WhiteSpace_ForceTabIndentSniff extends Generic_Sniffs_WhiteSpace_DisallowTabIndentSniff
-{
+class CakePHP_Sniffs_WhiteSpace_TabAndSpaceSniff implements PHP_CodeSniffer_Sniff {
+
+/**
+ * A list of tokenizers this sniff supports.
+ *
+ * @var array
+ */
+	public $supportedTokenizers = array(
+		'PHP',
+		'JS',
+		'CSS'
+	);
+
+/**
+ * Returns an array of tokens this test wants to listen for.
+ *
+ * @return array
+ */
+	public function register() {
+		return array(T_WHITESPACE);
+	}
 
 /**
  * Processes this test, when one of its tokens is encountered.
@@ -28,16 +47,21 @@ class CakePHP_Sniffs_WhiteSpace_ForceTabIndentSniff extends Generic_Sniffs_White
 		$tokens = $phpcsFile->getTokens();
 
 		$line = $tokens[$stackPtr]['line'];
-		if ($stackPtr > 0 && $tokens[($stackPtr - 1)]['line'] === $line) {
+		if ($stackPtr > 0 && $tokens[($stackPtr - 1)]['line'] !== $line) {
 			return;
 		}
 
-		if (preg_match('@^  @', $tokens[$stackPtr]['content'])) {
-			$error = 'Space indented: Tabs for indents, spaces for alignment';
+		if (strpos($tokens[$stackPtr]['content'], "  ") !== false) {
+			$error = 'Double space found';
 			$phpcsFile->addError($error, $stackPtr);
-		} elseif (preg_match('@\t [^\*]@', $tokens[$stackPtr]['content'])) {
-			$error = 'Tab followed by space - bad indentation';
-			$phpcsFile->addWarning($error, $stackPtr);
+		}
+		if (strpos($tokens[$stackPtr]['content'], " \t") !== false) {
+			$error = 'Space and tab found';
+			$phpcsFile->addError($error, $stackPtr);
+		}
+		if (strpos($tokens[$stackPtr]['content'], "\t ") !== false) {
+			$error = 'Tab and space found';
+			$phpcsFile->addError($error, $stackPtr);
 		}
 	}
 

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -54,6 +54,7 @@
  <rule ref="Squiz.Scope.StaticThisUsage"/>
 
  <rule ref="Squiz.WhiteSpace.CastSpacing"/>
+ <rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
  <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
  <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
  <rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>

--- a/tests/files/double_space.php
+++ b/tests/files/double_space.php
@@ -1,0 +1,2 @@
+<?php
+$var  = 'double space';

--- a/tests/files/mixing_indent.php
+++ b/tests/files/mixing_indent.php
@@ -1,0 +1,6 @@
+<?php
+if ($indented) {
+	$var = array(
+		 'space' => 'after 2 tabs'
+	 );
+}

--- a/tests/files/space_tab.php
+++ b/tests/files/space_tab.php
@@ -1,0 +1,2 @@
+<?php
+$var 	= 'space and tab';

--- a/tests/files/tab_space.php
+++ b/tests/files/tab_space.php
@@ -1,0 +1,2 @@
+<?php
+$var	 = 'tab and space';


### PR DESCRIPTION
...Generic.WhiteSpace.DisallowSpaceIndent instead

This fixes: https://github.com/cakephp/cakephp-codesniffer/issues/13

I ***\* at regexes, it might be done easier perhaps
