### PR TITLE
[bug] include and require have conflict in rules

### DIFF
--- a/Sniffs/WhiteSpace/FunctionCallSpacingSniff.php
+++ b/Sniffs/WhiteSpace/FunctionCallSpacingSniff.php
@@ -20,10 +20,6 @@ class CakePHP_Sniffs_WhiteSpace_FunctionCallSpacingSniff implements PHP_CodeSnif
 		return array(
 			T_ISSET,
 			T_EMPTY,
-			T_INCLUDE,
-			T_INCLUDE_ONCE,
-			T_REQUIRE,
-			T_REQUIRE_ONCE,
 			T_STRING,
 		);
 	}


### PR DESCRIPTION
In the 0.1.12 release from pear is a serious bug. 'include (' with a space is wrong because:

```
ERROR | Space before opening parenthesis of function call not allowed
```

When space removed:

```
ERROR | Language constructs must be followed by a single space; expected
     |       | "include (" but found "include("
```
