### PR TITLE
Improved readme

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -10,7 +10,7 @@ Installation
 Its generally recommended to install these code sniffs with the PEAR
 installer:
 
-    pear channel-discover pear.cakephp.org
+	pear channel-discover pear.cakephp.org
 	pear install cakephp/CakePHP_CodeSniffer
 
 Usage


### PR DESCRIPTION
Added build status and a note about phpunit failing with a default clone of the repo.

See [ceeram's note](https://github.com/cakephp/cakephp-codesniffer/commit/81d70cb56fef03f3dca1808dc3cac45840e11400#commitcomment-3482308).
