### PR TITLE
if, while, foreach and for statements without brackets aren't detected

### DIFF
--- a/Sniffs/ControlStructures/ControlStructuresSniff.php
+++ b/Sniffs/ControlStructures/ControlStructuresSniff.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * CakePHP_Sniffs_ControlStructures_ControlStructuresSniff
+ *
+ * PHP 5
+ *
+ * Ensures curly brackets are used with if, else, elseif, foreach and for.
+ * while and dowhile are covered elsewhere
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://pear.php.net/package/PHP_CodeSniffer_CakePHP
+ * @package       PHP_CodeSniffer_CakePHP
+ * @since         CakePHP CodeSniffer 0.1.14
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+class CakePHP_Sniffs_ControlStructures_ControlStructuresSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(T_IF, T_ELSEIF, T_ELSE, T_FOREACH, T_FOR);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * Checks that curly brackets are used with if, else, elseif, foreach and for.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token in the
+	 *                                        stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+
+		$nextToken = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+		if ($tokens[$nextToken]['code'] === T_OPEN_PARENTHESIS) {
+			$closer = $tokens[$nextToken]['parenthesis_closer'];
+			$diff = $closer - $stackPtr;
+			$nextToken = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + $diff + 1), null, true);
+		}
+		if ($tokens[$nextToken]['code'] === T_IF) {
+			// "else if" is not checked by this sniff, another sniff takes care of that.
+			return;
+		}
+		if ($tokens[$nextToken]['code'] !== T_OPEN_CURLY_BRACKET && $tokens[$nextToken]['code'] !== T_COLON) {
+			$error = 'Curly brackets required for if/elseif/else.';
+			$phpcsFile->addError($error, $stackPtr, 'NotAllowed');
+		}
+	}
+
+}

--- a/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
+++ b/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * CakePHP_Sniffs_ControlStructures_ElseIfDeclarationSniff
+ *
+ * PHP 5
+ *
+ * Ensures that elseif is used instead of else if
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://pear.php.net/package/PHP_CodeSniffer_CakePHP
+ * @package       PHP_CodeSniffer_CakePHP
+ * @since         CakePHP CodeSniffer 0.1.14
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+class CakePHP_Sniffs_ControlStructures_ElseIfDeclarationSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(T_ELSE);
+
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * Checks that ELSEIF is used instead of ELSE IF.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token in the
+	 *                                        stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+
+		$nextToken = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+		if ($tokens[$nextToken]['code'] !== T_IF) {
+			return;
+		}
+
+		$error = 'Usage of ELSE IF not allowed; use ELSEIF instead';
+		$phpcsFile->addError($error, $stackPtr, 'NotAllowed');
+
+	}
+
+}

--- a/Sniffs/ControlStructures/WhileStructuresSniff.php
+++ b/Sniffs/ControlStructures/WhileStructuresSniff.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * CakePHP_Sniffs_ControlStructures_WhileStructuresSniff
+ *
+ * PHP 5
+ *
+ * Ensures that while and do-while use curly brackets
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://pear.php.net/package/PHP_CodeSniffer_CakePHP
+ * @package       PHP_CodeSniffer_CakePHP
+ * @since         CakePHP CodeSniffer 0.1.14
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+class CakePHP_Sniffs_ControlStructures_WhileStructuresSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(T_DO, T_WHILE);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * Checks that while and do-while use curly brackets
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token in the
+	 *                                        stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+
+		$nextToken = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+		if ($tokens[$nextToken]['code'] === T_OPEN_PARENTHESIS) {
+			$closer = $tokens[$nextToken]['parenthesis_closer'];
+			$diff = $closer - $stackPtr;
+			$nextToken = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + $diff + 1), null, true);
+		}
+
+		if ($tokens[$stackPtr]['code'] === T_WHILE && $tokens[$nextToken]['code'] === T_SEMICOLON) {
+			/* This while is probably part of a do-while construction, skip it .. */
+			return;
+		}
+		if ($tokens[$nextToken]['code'] !== T_OPEN_CURLY_BRACKET && $tokens[$nextToken]['code'] !== T_COLON) {
+			$error = 'Curly brackets required in a do-while or while loop';
+			$phpcsFile->addError($error, $stackPtr, 'NotAllowed');
+		}
+	}
+
+}

--- a/Sniffs/Formatting/UseInAlphabeticalOrderSniff.php
+++ b/Sniffs/Formatting/UseInAlphabeticalOrderSniff.php
@@ -74,7 +74,7 @@ class CakePHP_Sniffs_Formatting_UseInAlphabeticalOrderSniff implements PHP_CodeS
 			$end = $phpcsFile->findNext(array(T_SEMICOLON, T_OPEN_CURLY_BRACKET),  $next);
 			$useTokens = array_slice($tokens, $next, $end - $next, true);
 			foreach ($useTokens as $index => $token) {
-				if ($token['type'] === 'T_STRING' || $token['type'] === 'T_NS_SEPARATOR') {
+				if ($token['code'] === T_STRING || $token['code'] === T_NS_SEPARATOR) {
 					$content .= $token['content'];
 				}
 			}

--- a/tests/files/control_structure_brackets_pass.php
+++ b/tests/files/control_structure_brackets_pass.php
@@ -1,0 +1,19 @@
+<?php
+
+for ($i = 0; $i < 10; $i++) {
+	echo 'hello';
+}
+
+if ($i < 10) {
+	echo 'hello2';
+} elseif ($i > 100) {
+	echo 'i > 100';
+}
+
+while (false) {
+	echo 'false';
+}
+
+do {
+	echo 'dowhile test';
+} while (false);

--- a/tests/files/control_structure_dowhile.php
+++ b/tests/files/control_structure_dowhile.php
@@ -1,0 +1,6 @@
+<?php
+
+do
+        echo 'dowhile test';
+while (false);
+

--- a/tests/files/control_structure_elseif.php
+++ b/tests/files/control_structure_elseif.php
@@ -1,0 +1,6 @@
+<?php
+if (isset($a)) {
+	echo 'a isset';
+} else if (isset($b)) {
+	echo 'b isset';
+}

--- a/tests/files/control_structure_nobrackets.php
+++ b/tests/files/control_structure_nobrackets.php
@@ -1,0 +1,4 @@
+<?php
+
+if($abc == true)
+        echo 'hello';

--- a/tests/files/control_structure_nospace.php
+++ b/tests/files/control_structure_nospace.php
@@ -1,0 +1,4 @@
+<?php
+if(isset($test)) {
+	echo 'hello';
+}

--- a/tests/files/control_structure_while.php
+++ b/tests/files/control_structure_while.php
@@ -1,0 +1,4 @@
+<?php
+while (false)
+        echo 'false';
+

--- a/tests/files/inline_if_pass.php
+++ b/tests/files/inline_if_pass.php
@@ -1,10 +1,10 @@
-<?php if ($something): ?>
+<?php if ($something) : ?>
 	<div>
 		<p>Some blob of html</p>
 	</div>
 <?php endif; ?>
-<?php if ($something): ?>
-	<?php if ($somethingElse): ?>
+<?php if ($something) : ?>
+	<?php if ($somethingElse) : ?>
 		<p>Hi there!</p>
 	<?php endif; ?>
 <?php endif; ?>


### PR DESCRIPTION
If no brackets are supplied the if-statement is skipped.
e.g.

``` php
if($abc == true)
        echo 'hello';

if ($abc == true)  
        echo 'hello';
else
        echo 'good-bye';
```

Above is valid according to the codesniffer.
