### PR TITLE
White-space after comma sniff from issue #37

### DIFF
--- a/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -1,0 +1,43 @@
+<?php
+
+class CakePHP_Sniffs_WhiteSpace_CommaSpacingSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(T_COMMA);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile All the tokens found in the document.
+	 * @param int $stackPtr The position of the current token
+	 *    in the stack passed in $tokens.
+	 * @return void
+	 */
+	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+
+		$next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+
+		if ($tokens[$next]['code'] !== T_WHITESPACE && ($next !== $stackPtr + 2)) {
+			// Last character in a line is ok.
+			if ($tokens[$next]['line'] === $tokens[$stackPtr]['line']) {
+				$error = 'Missing space after comma';
+				$phpcsFile->addError($error, $next);
+			}
+		}
+
+		$previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+
+		if ($tokens[$previous]['code'] !== T_WHITESPACE && ($previous !== $stackPtr - 1)) {
+			$error = 'Space before comma, expected none, though';
+			$phpcsFile->addError($error, $next);
+		}
+	}
+
+}

--- a/tests/files/whitespace_comma.php
+++ b/tests/files/whitespace_comma.php
@@ -1,0 +1,2 @@
+<?php
+	echo implode('', array_map('chr', array_map('hexdec',array_filter(explode($delimiter, $string)))));

--- a/tests/files/whitespace_comma_pass.php
+++ b/tests/files/whitespace_comma_pass.php
@@ -1,0 +1,2 @@
+<?php
+	echo implode('', array_map('chr', array_map('hexdec', array_filter(explode($delimiter, $string)))));


### PR DESCRIPTION
I've added the white-space after comma sniff from dereuromark in a pull-request.

See issue #37
