### PR TITLE
Added whitespace before comma test, fixes issue #37

### DIFF
--- a/tests/files/whitespace_comma_before.php
+++ b/tests/files/whitespace_comma_before.php
@@ -1,0 +1,2 @@
+<?php
+	echo implode('', array_map('chr', array_map('hexdec' , array_filter(explode($delimiter, $string)))));


### PR DESCRIPTION
I've added a missing test for the white-space check before the comma. This completes issue #37.
