### PR TITLE
Allow short open tags

### DIFF
--- a/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * PHP Version 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://pear.php.net/package/PHP_CodeSniffer_CakePHP
+ * @since         CakePHP CodeSniffer 0.1.14
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Disallow short open tags
+ *
+ * But permit short-open echo tags (<?=) as they are part of PHP 5.4+
+ *
+ */
+class CakePHP_Sniffs_PHP_DisallowShortOpenTagSniff implements PHP_CodeSniffer_Sniff {
+
+/**
+ * Returns an array of tokens this test wants to listen for.
+ *
+ * If short open tags are NOT enabled, <? is not considered a T_OPEN_TAG
+ * So include T_INLINE_HTML which is what "<?" is detected as
+ *
+ * @return array
+ */
+	public function register() {
+		return array(
+			T_OPEN_TAG,
+			T_INLINE_HTML
+		);
+	}
+
+/**
+ * Processes this test, when one of its tokens is encountered.
+ *
+ * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+ * @param int                  $stackPtr  The position of the current token in the
+ *                             stack passed in $tokens.
+ *
+ * @return void
+ */
+	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$openTag = $tokens[$stackPtr];
+
+		if (trim($openTag['content']) === '<?') {
+			$error = 'Short PHP opening tag used; expected "<?php" but found "%s"';
+			$data = array($openTag['content']);
+			$phpcsFile->addError($error, $stackPtr, 'Found', $data);
+		}
+	}
+}

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -45,7 +45,6 @@
 
  <rule ref="Generic.PHP.DeprecatedFunctions"/>
  <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
- <rule ref="Generic.PHP.DisallowShortOpenTag"/>
  <rule ref="Squiz.PHP.Eval"/>
  <rule ref="Generic.PHP.ForbiddenFunctions"/>
  <rule ref="Squiz.PHP.NonExecutableCode"/>

--- a/tests/files/short_open_tags_fail.php
+++ b/tests/files/short_open_tags_fail.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * If shortopen tags are not enabled phpcs will report that the file has no php code
+ * Ensure that there is some php code to skip that logic
+ */
+$ensure = 'some php code'; ?>
+
+<?
+echo "this should fail";

--- a/tests/files/short_open_tags_pass.php
+++ b/tests/files/short_open_tags_pass.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * If shortopen tags are not enabled phpcs will report that the file has no php code
+ * Ensure that there is some php code to skip that logic
+ */
+$ensure = 'some php code'; ?>
+
+<?= "this should pass";


### PR DESCRIPTION
PHP 5.4 permits `<?=`, as such this permutation of short-open-tags should be considered valid.

Is it worth writing another sniff to ensure that actual short open tags aren't in use?
