### PR TITLE
this sniff doesn't apply to "use" in closures

### DIFF
--- a/Sniffs/Formatting/UseInAlphabeticalOrderSniff.php
+++ b/Sniffs/Formatting/UseInAlphabeticalOrderSniff.php
@@ -58,6 +58,18 @@ class CakePHP_Sniffs_Formatting_UseInAlphabeticalOrderSniff implements PHP_CodeS
 
 		$tokens = $phpcsFile->getTokens();
 
+		$isClosure = $phpcsFile->findPrevious(
+			array(T_CLOSURE),
+			($stackPtr - 1),
+			null,
+			false,
+			null,
+			true
+		);
+		if ($isClosure) {
+			return;
+		}
+
 		// Only one USE declaration allowed per statement.
 		$next = $phpcsFile->findNext(array(T_COMMA, T_SEMICOLON), ($stackPtr + 1));
 		if ($tokens[$next]['code'] === T_COMMA) {

--- a/tests/files/use_closure_pass.php
+++ b/tests/files/use_closure_pass.php
@@ -1,0 +1,8 @@
+<?php
+
+$foo = 'bar';
+$bar = 'foo';
+
+$zum = function() use ($foo, $bar) {
+	return $foo;
+};


### PR DESCRIPTION
Unfortunately T_USE is the same token for:

```
<?php
use Foo;
```

and in a closure:

```
$foo = function () use ($bar) {
};
```
