### PR TITLE
Simplify and reduce redundancy.

### DIFF
--- a/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -85,28 +85,14 @@ class CakePHP_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_
 				if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
 					$error = 'Expected 1 space before "&" operator; 0 found';
 					$phpcsFile->addError($error, $stackPtr, 'NoSpaceBeforeAmp');
-				} else {
-					if (strlen($tokens[($stackPtr - 1)]['content']) !== 1) {
-						$found = strlen($tokens[($stackPtr - 1)]['content']);
-						$error = 'Expected 1 space before "&" operator; %s found';
-						$data = array($found);
-						$phpcsFile->addError($error, $stackPtr, 'SpacingBeforeAmp', $data);
-					}
 				}
 
 				// Check there is one space after the & operator.
 				if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
 					$error = 'Expected 1 space after "&" operator; 0 found';
 					$phpcsFile->addError($error, $stackPtr, 'NoSpaceAfterAmp');
-				} else {
-					if (strlen($tokens[($stackPtr + 1)]['content']) !== 1) {
-						$found = strlen($tokens[($stackPtr + 1)]['content']);
-						$error = 'Expected 1 space after "&" operator; %s found';
-						$data = array($found);
-						$phpcsFile->addError($error, $stackPtr, 'SpacingAfterAmp', $data);
-					}
 				}
-			}//end if
+			}
 		} else {
 			if ($tokens[$stackPtr]['code'] === T_MINUS) {
 				// Check minus spacing, but make sure we aren't just assigning
@@ -152,36 +138,14 @@ class CakePHP_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_
 
 			$operator = $tokens[$stackPtr]['content'];
 
-			$content = str_replace("\r\n", "\n", $tokens[($stackPtr - 1)]['content']);
 			if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
 				$error = "Expected 1 space before \"$operator\"; 0 found";
 				$phpcsFile->addError($error, $stackPtr, 'NoSpaceBefore');
-			} elseif (strlen($content) !== 1) {
-				// Don't throw an error for assignments, because other standards allow
-				// multiple spaces there to align multiple assignments.
-				if (in_array($tokens[$stackPtr]['code'], PHP_CodeSniffer_Tokens::$assignmentTokens) === false) {
-					$found = strlen($content);
-					$error = 'Expected 1 space before "%s"; %s found';
-					$data = array(
-						$operator,
-						$found,
-					);
-					$phpcsFile->addError($error, $stackPtr, 'SpacingBefore', $data);
-				}
 			}
 
-			$content = str_replace("\r\n", "\n", $tokens[($stackPtr + 1)]['content']);
 			if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
 				$error = "Expected 1 space after \"$operator\"; 0 found";
 				$phpcsFile->addError($error, $stackPtr, 'NoSpaceAfter');
-			} elseif (strlen($content) !== 1) {
-				$found = strlen($content);
-				$error = 'Expected 1 space after "%s"; %s found';
-				$data = array(
-					$operator,
-					$found,
-				);
-				$phpcsFile->addError($error, $stackPtr, 'SpacingAfter', $data);
 			}
 		}
 	}


### PR DESCRIPTION
I recommend simplifying this sniff. There is no need for the redundancy.
Currently it would report everything twice:

```
12 | ERROR | Double space found (CakePHP.WhiteSpace.TabAndSpace)
12 | ERROR | Expected 1 space before "*"; 2 found
    |       | (CakePHP.WhiteSpace.OperatorSpacing.SpacingBefore)
```

All we need, though, is the 0 space issue:

```
8 | ERROR | Expected 1 space after "*"; 0 found
   |       | (CakePHP.WhiteSpace.OperatorSpacing.NoSpaceAfter)
```

Also, using phpcs-fixer then later on, multi-spaces will also be automatically corrected via TabAndSpace sniff anyway.
