### PR TITLE
Minor correction and cleanup.

### DIFF
--- a/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -147,13 +147,12 @@ class CakePHP_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSn
 				$data = array($varName);
 				$phpcsFile->addError($error, $stackPtr, 'PrivateNoUnderscore', $data);
 				return;
-			} else {
-				$filename = $phpcsFile->getFilename();
-				if (strpos($filename, '/lib/Cake/') !== false) {
-					$warning = 'Private variable "%s" in CakePHP core is discouraged';
-					$data = array($varName);
-					$phpcsFile->addWarning($warning, $stackPtr, 'PrivateInCore', $data);
-				}
+			}
+			$filename = $phpcsFile->getFilename();
+			if (strpos($filename, '/lib/Cake/') !== false) {
+				$warning = 'Private variable "%s" in CakePHP core is discouraged';
+				$data = array($varName);
+				$phpcsFile->addWarning($warning, $stackPtr, 'PrivateInCore', $data);
 			}
 		} else {
 			if (substr($varName, 0, 1) !== '_') {
@@ -219,7 +218,6 @@ class CakePHP_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSn
 				}
 
 				if ($this->_isValidVar($varName) === false) {
-					$varName = $matches[0];
 					$error = 'Variable "%s" is not in valid camel caps format';
 					$data = array($originalVarName);
 					$phpcsFile->addError($error, $stackPtr, 'StringVarNotCamelCaps', $data);

--- a/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -18,7 +18,7 @@
 /**
  * Disallow short open tags
  *
- * But permit short-open echo tags (<?=) as they are part of PHP 5.4+
+ * But permit short-open echo tags (<?=) [T_OPEN_TAG_WITH_ECHO] as they are part of PHP 5.4+
  *
  */
 class CakePHP_Sniffs_PHP_DisallowShortOpenTagSniff implements PHP_CodeSniffer_Sniff {
@@ -53,8 +53,9 @@ class CakePHP_Sniffs_PHP_DisallowShortOpenTagSniff implements PHP_CodeSniffer_Sn
 
 		if (trim($openTag['content']) === '<?') {
 			$error = 'Short PHP opening tag used; expected "<?php" but found "%s"';
-			$data = array($openTag['content']);
+			$data = array(trim($openTag['content']));
 			$phpcsFile->addError($error, $stackPtr, 'Found', $data);
 		}
 	}
+
 }

--- a/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -106,7 +106,7 @@ class CakePHP_Sniffs_WhiteSpace_OperatorSpacingSniff implements PHP_CodeSniffer_
 						$phpcsFile->addError($error, $stackPtr, 'SpacingAfterAmp', $data);
 					}
 				}
-			}//end if
+			}
 		} else {
 			if ($tokens[$stackPtr]['code'] === T_MINUS) {
 				// Check minus spacing, but make sure we aren't just assigning

--- a/Sniffs/WhiteSpace/TabAndSpaceSniff.php
+++ b/Sniffs/WhiteSpace/TabAndSpaceSniff.php
@@ -58,7 +58,7 @@ class CakePHP_Sniffs_WhiteSpace_TabAndSpaceSniff implements PHP_CodeSniffer_Snif
 			return;
 		}
 
-		if (strpos($tokens[$stackPtr]['content'], "  ") !== false) {
+		if (strpos($tokens[$stackPtr]['content'], '  ') !== false) {
 			$error = 'Double space found';
 			$phpcsFile->addError($error, $stackPtr);
 		}


### PR DESCRIPTION
Short open tags need trim() for output to avoid an accidental newline to be inserted, messing up the report.
