### PR TITLE
Prevent double report.

### DIFF
--- a/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -86,8 +86,7 @@ class CakePHP_Sniffs_NamingConventions_ValidFunctionNameSniff extends PHP_CodeSn
 
 		$methodProps = $phpcsFile->getMethodProperties($stackPtr);
 		if ($methodProps['scope_specified'] === false) {
-			$error = 'All methods must have a scope specified';
-			$phpcsFile->addError($error, $stackPtr, 'NoScopeSpecified', $errorData);
+			// Let another sniffer take care of that
 			return;
 		}
 

--- a/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -62,7 +62,7 @@ class CakePHP_Sniffs_WhiteSpace_FunctionSpacingSniff implements PHP_CodeSniffer_
 			}
 		}
 
-		if (is_null($nextLineToken) === true) {
+		if ($nextLineToken === null) {
 			// Never found the next line, which means
 			// there are 0 blank lines after the function.
 			$foundLines = 0;
@@ -97,7 +97,7 @@ class CakePHP_Sniffs_WhiteSpace_FunctionSpacingSniff implements PHP_CodeSniffer_
 			}
 		}
 
-		if (is_null($prevLineToken) === true) {
+		if ($prevLineToken === null) {
 			// Never found the previous line, which means
 			// there are 0 blank lines before the function.
 			$foundLines = 0;
@@ -111,7 +111,7 @@ class CakePHP_Sniffs_WhiteSpace_FunctionSpacingSniff implements PHP_CodeSniffer_
 			$prevLine = ($tokens[$prevContent]['line'] - 1);
 			$i = ($stackPtr - 1);
 			$foundLines = 0;
-			while ($currentLine != $prevLine && $currentLine > 1 && $i > 0) {
+			while ($currentLine !== $prevLine && $currentLine > 1 && $i > 0) {
 				if (isset($tokens[$i]['scope_condition']) === true) {
 					$scopeCondition = $tokens[$i]['scope_condition'];
 					if ($tokens[$scopeCondition]['code'] === T_FUNCTION) {


### PR DESCRIPTION
The Squiz.Scope.MethodScope sniff already checks for not set visibility.
No need to report it twice.
This sniff should only check - on top of the existing basic one - if the scope matches the variable name.
