### PR TITLE
Removing check for PHP4 style constructor.

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -37,7 +37,6 @@
  <rule ref="PSR2.Namespaces.NamespaceDeclaration"/>
  <rule ref="PSR2.Namespaces.UseDeclaration"/>
 
- <rule ref="Generic.NamingConventions.ConstructorName"/>
  <!--
  Disabled and replaced with local copy. See http://pear.php.net/bugs/bug.php?id=19957
  <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>


### PR DESCRIPTION
This sniff causes unnecessary noise for 3.0 branch where class `Table` has method `table()`.
