### PR TITLE
Removed "useless method overriding" sniff.

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -15,7 +15,6 @@
  <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
  <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
  <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
- <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
 
  <rule ref="Squiz.Commenting.DocCommentAlignment"/>
  <rule ref="Generic.Commenting.Todo"/>


### PR DESCRIPTION
It's not smart enough and doesn't detect changed default arguments.

Reports false errors such as [this](https://travis-ci.org/cakephp/cakephp/jobs/16070422#L151).
