### PR TITLE
Added PHP 5.6's new "debugInfo" to magic methods list.

### DIFF
--- a/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -32,6 +32,7 @@ class CakePHP_Sniffs_NamingConventions_ValidFunctionNameSniff extends PHP_CodeSn
 		'destruct',
 		'call',
 		'callStatic',
+		'debugInfo',
 		'get',
 		'set',
 		'isset',


### PR DESCRIPTION
Refs cakephp/cakephp#2975
