### PR TITLE
phpcs won't work with a symlink

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -26,11 +26,11 @@ installed phpcs, and this package with PEAR, you can do the following:
 	phpcs --standard=CakePHP /path/to/code
 
 *Warning* when these sniffs are installed with composer, you cannot use them as installed because
-of how phpcs handles classnames. It is advised that you symlink these sniffs into phpcs:
+of how phpcs handles classnames. It is advised that you copy these sniffs into phpcs:
 
-	ln -s `pwd`/vendor/cakephp/cakephp-codesniffer vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/CakePHP
+	cp -R vendor/cakephp/cakephp-codesniffer vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/CakePHP
 
-Once the symlink has been created (or you copied the files over) you can run phpcs using:
+Once the standard has been put where phpcs can find it, you can run phpcs using:
 
 	vendor/bin/phpcs --standard=CakePHP
 


### PR DESCRIPTION
As was, it doesn't work:

```
-> composer require cakephp/cakephp-codesniffer
Warning: This development build of composer is over 30 days old. It is recommended to update it by running "/usr/local/bin/composer self-update" to get the latest version.
Please provide a version constraint for the cakephp/cakephp-codesniffer requirement: dev-master
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Installing squizlabs/php_codesniffer (1.5.3)
    Downloading: 100%         

  - Installing cakephp/cakephp-codesniffer (dev-master af529d9)
    Cloning af529d98a3904f078ff2db5a9041a98d3a60b90c

Writing lock file
Generating autoload files
www-data @ dev [ /var/www/crud.dev/htdocs ] (master *%=)
-> ln -s `pwd`/vendor/cakephp/cakephp-codesniffer vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/CakePHP
www-data @ dev [ /var/www/crud.dev/htdocs ] (master *%=)
-> vendor/bin/phpcs --standard=CakePHP App/

Fatal error: Class 'cakephp-codesniffer_Sniffs_ControlStructures_ControlStructuresSniff' not found in /var/www/crud.dev/htdocs/vendor/squizlabs/php_codesniffer/CodeSniffer.php on line 1053

Call Stack:
    0.0001     229200   1. {main}() /var/www/crud.dev/htdocs/vendor/squizlabs/php_codesniffer/scripts/phpcs:0
    0.0298    1192144   2. PHP_CodeSniffer_CLI->process() /var/www/crud.dev/htdocs/vendor/squizlabs/php_codesniffer/scripts/phpcs:37
    0.0308    1240944   3. PHP_CodeSniffer->process() /var/www/crud.dev/htdocs/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php:614
    0.0940    2741832   4. PHP_CodeSniffer->populateTokenListeners() /var/www/crud.dev/htdocs/vendor/squizlabs/php_codesniffer/CodeSniffer.php:445
```

There will be an "opertune" realpath somewhere. Like this however it does work:

```
www-data @ dev [ /var/www/crud.dev/htdocs ] (master *%=)
-> rm vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/CakePHP
www-data @ dev [ /var/www/crud.dev/htdocs ] (master *%=)
-> cp -R `pwd`/vendor/cakephp/cakephp-codesniffer vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/CakePHP
www-data @ dev [ /var/www/crud.dev/htdocs ] (master *%=)
-> vendor/bin/phpcs --standard=CakePHP App/

FILE: /var/www/crud.dev/htdocs/App/Config/Schema/i18n.php
--------------------------------------------------------------------------------
FOUND 2 ERROR(S) AFFECTING 2 LINE(S)
--------------------------------------------------------------------------------
 31 | ERROR | Missing function doc comment
 35 | ERROR | Missing function doc comment
-------------------------------------------------------------------.......
```
