### PR TITLE
Remove alignment checks

### DIFF
--- a/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Sniffs/Commenting/FunctionCommentSniff.php
@@ -352,33 +352,6 @@ class CakePHP_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_
 
                 $paramName = ($param->getVarName() !== '') ? $param->getVarName() : '[ UNKNOWN ]';
 
-                if ($previousParam !== null) {
-                    $previousName = ($previousParam->getVarName() !== '') ? $previousParam->getVarName() : 'UNKNOWN';
-
-                    // Check to see if the parameters align properly.
-                    if ($param->alignsVariableWith($previousParam) === false) {
-                        $error = 'The variable names for parameters %s (%s) and %s (%s) do not align';
-                        $data  = array(
-                                  $previousName,
-                                  ($pos - 1),
-                                  $paramName,
-                                  $pos,
-                                 );
-                        $this->currentFile->addError($error, $errorPos, 'ParameterNamesNotAligned', $data);
-                    }
-
-                    if ($param->alignsCommentWith($previousParam) === false) {
-                        $error = 'The comments for parameters %s (%s) and %s (%s) do not align';
-                        $data  = array(
-                                  $previousName,
-                                  ($pos - 1),
-                                  $paramName,
-                                  $pos,
-                                 );
-                        $this->currentFile->addError($error, $errorPos, 'ParameterCommentsNotAligned', $data);
-                    }
-                }//end if
-
                 // Make sure the names of the parameter comment matches the
                 // actual parameter.
                 if (isset($realParams[($pos - 1)]) === true) {


### PR DESCRIPTION
We should not check comment column alignments:
- noisy on existing codebase (https://gist.github.com/rchavik/064f47c19396b24f7975)
- unnecessary changes for new PR, eg: adding a new variable might cause the first variable to be re-aligned

``` diff
diff --git a/Nodes/Controller/NodesController.php b/Nodes/Controller/NodesContr
index 27319db..361fb89 100644
--- a/Nodes/Controller/NodesController.php
+++ b/Nodes/Controller/NodesController.php
@@ -90,7 +90,7 @@ class NodesController extends NodesAppController {
  * Toggle Node status
  *
- * @param $id string   Node id
+ * @param $id string       Node id
+ * @param $status integer  Current Node status
```
