### PR TITLE
Prevent errors reporting for docblock with {@inheritDoc} tag.

### DIFF
--- a/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
@@ -160,8 +160,9 @@ class CakePHP_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_
 
         // If the first T_OPEN_TAG is right before the comment, it is probably
         // a file comment.
-        $commentStart = ($phpcsFile->findPrevious(T_DOC_COMMENT, ($commentEnd - 1), null, true) + 1);
-        $prevToken    = $phpcsFile->findPrevious(T_WHITESPACE, ($commentStart - 1), null, true);
+        $commentStart  = ($phpcsFile->findPrevious(T_DOC_COMMENT, ($commentEnd - 1), null, true) + 1);
+        $commentString = $phpcsFile->getTokensAsString($commentStart, $commentEnd - $commentStart + 1);
+        $prevToken     = $phpcsFile->findPrevious(T_WHITESPACE, ($commentStart - 1), null, true);
         if ($tokens[$prevToken]['code'] === T_OPEN_TAG) {
             // Is this the first open tag?
             if ($stackPtr === 0 || $phpcsFile->findPrevious(T_OPEN_TAG, ($prevToken - 1)) === false) {
@@ -186,6 +187,22 @@ class CakePHP_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_
         if (is_null($comment) === true) {
             $error = 'Function doc comment is empty';
             $phpcsFile->addError($error, $commentStart, 'Empty');
+            return;
+        }
+
+        // The first line of the comment should just be the /** code.
+        $eolPos    = strpos($commentString, $phpcsFile->eolChar);
+        $firstLine = substr($commentString, 0, $eolPos);
+        if ($firstLine !== '/**') {
+            $phpcsFile->addError($commentStart, 'ContentAfterOpen');
+        }
+
+        // If the comment has an inherit doc note just move on
+        if (preg_match('/\{\@inheritDoc\}/', $commentString)) {
+            return;
+        } elseif (preg_match('/\{?\@?inherit[dD]oc\}?/', $commentString)) {
+            $error = 'The inheritdoc statement is incorrect';
+            $phpcsFile->addError($error, $commentStart, 'IncorrectInheritDoc');
             return;
         }
 

--- a/CakePHP/tests/files/for_function_comment_pass.php
+++ b/CakePHP/tests/files/for_function_comment_pass.php
@@ -1,0 +1,23 @@
+<?php
+class Foo {
+
+/**
+ * [doThing description]
+ *
+ * @param string $foo Foo
+ * @return void
+ */
+	public function doThing($foo) {
+	}
+
+}
+
+class Bar extends Foo {
+
+/**
+ * {@inheritDoc}
+ */
+	public function doThing($foo) {
+	}
+
+}


### PR DESCRIPTION
Found the code at squizlabs/PHP_CodeSniffer#214 :smile: 
