### PR TITLE
Relax comment sniff rules in test directories.

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -72,6 +72,7 @@
 
   <!-- 3.x dir structure -->
   <exclude-pattern>*/tests/TestCase/*</exclude-pattern>
+  <exclude-pattern>*/tests/test_app/*</exclude-pattern>
  </rule>
 
  <!-- All rules in ./Sniffs are included automatically -->


### PR DESCRIPTION
While its nice to have perfectly documented test cases, it is far less important than doing that for application/library code.

I thought this might be a decent way to get the PHPCS builds passing and fix plugins/app directories as well.
