### PR TITLE
Better errors for use statement sniffs

### DIFF
--- a/CakePHP/Sniffs/Formatting/UseInAlphabeticalOrderSniff.php
+++ b/CakePHP/Sniffs/Formatting/UseInAlphabeticalOrderSniff.php
@@ -124,7 +124,7 @@ class CakePHP_Sniffs_Formatting_UseInAlphabeticalOrderSniff implements PHP_CodeS
 		if (!empty($token['conditions'])) {
 			$scope = key($token['conditions']);
 		}
-		$this->_uses[$scope][$content] = 1;
+		$this->_uses[$scope][$content] = $stackPtr;
 	}
 
 /**


### PR DESCRIPTION
Fix up a few annoying issues with the use statement sniff.
- Give the correct line numbers.
- Give the expected result.

I find the current errors incredibly opaque and very tedious to fix, the updated errors are much simpler to work with.
