### PR TITLE
Adds a comment to clarify the correct error being tested with this file

### DIFF
--- a/CakePHP/tests/files/function_comment_opening_line_fail.php
+++ b/CakePHP/tests/files/function_comment_opening_line_fail.php
@@ -3,7 +3,7 @@
 class Foo {
 
 /** 
- * Some sentence.
+ * There is a (disallowed) trailing space after the opening ** in this doc block.
  *
  * @return void
  */


### PR DESCRIPTION
There is neither a comment nor clarity (to myself at least) what exactly this file was testing. When editing using an editor that automatically stripped trailing white space, this winds up throwing an error for the PHP Unit tests.

So I thought I would provide some clarity regarding what's being tested.
