### PR TITLE
Resolve undetected if ( $foo ) spaces

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -22,6 +22,7 @@
  <rule ref="PEAR.ControlStructures.ControlSignature"/>
  <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
  <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
+ <rule ref="PSR2.ControlStructures.ControlStructureSpacing"/>
 
  <rule ref="Zend.Files.ClosingTag"/>
  <rule ref="Generic.Files.LineEndings"/>


### PR DESCRIPTION
Fixes undetected CS errors as the ones @ https://github.com/cakephp/cakephp/pull/5334
