### PR TITLE
Exclude PSR2 sniffs which throw warnings for underscore prefix.

### DIFF
--- a/CakePHP/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/CakePHP/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Verifies that properties are declared correctly.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+if (class_exists('PHP_CodeSniffer_Standards_AbstractVariableSniff', true) === false) {
+    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractVariableSniff not found');
+}
+
+/**
+ * Verifies that properties are declared correctly.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class CakePHP_Sniffs_Classes_PropertyDeclarationSniff extends PHP_CodeSniffer_Standards_AbstractVariableSniff
+{
+
+    /**
+     * Processes the function tokens within the class.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file where this token was found.
+     * @param int                  $stackPtr  The position where the token was found.
+     *
+     * @return void
+     */
+    protected function processMemberVar(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Detect multiple properties defined at the same time. Throw an error
+        // for this, but also only process the first property in the list so we don't
+        // repeat errors.
+        $find = PHP_CodeSniffer_Tokens::$scopeModifiers;
+        $find = array_merge($find, array(T_VARIABLE, T_VAR, T_SEMICOLON));
+        $prev = $phpcsFile->findPrevious($find, ($stackPtr - 1));
+        if ($tokens[$prev]['code'] === T_VARIABLE) {
+            return;
+        }
+
+        if ($tokens[$prev]['code'] === T_VAR) {
+            $error = 'The var keyword must not be used to declare a property';
+            $phpcsFile->addError($error, $stackPtr, 'VarUsed');
+        }
+
+        $next = $phpcsFile->findNext(array(T_VARIABLE, T_SEMICOLON), ($stackPtr + 1));
+        if ($tokens[$next]['code'] === T_VARIABLE) {
+            $error = 'There must not be more than one property declared per statement';
+            $phpcsFile->addError($error, $stackPtr, 'Multiple');
+        }
+
+        $modifier = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$scopeModifiers, $stackPtr);
+        if (($modifier === false) || ($tokens[$modifier]['line'] !== $tokens[$stackPtr]['line'])) {
+            $error = 'Visibility must be declared on property "%s"';
+            $data  = array($tokens[$stackPtr]['content']);
+            $phpcsFile->addError($error, $stackPtr, 'ScopeMissing', $data);
+        }
+
+    }//end processMemberVar()
+
+
+    /**
+     * Processes normal variables.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file where this token was found.
+     * @param int                  $stackPtr  The position where the token was found.
+     *
+     * @return void
+     */
+    protected function processVariable(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        /*
+            We don't care about normal variables.
+        */
+
+    }//end processVariable()
+
+
+    /**
+     * Processes variables in double quoted strings.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file where this token was found.
+     * @param int                  $stackPtr  The position where the token was found.
+     *
+     * @return void
+     */
+    protected function processVariableInString(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        /*
+            We don't care about normal variables.
+        */
+
+    }//end processVariableInString()
+
+
+}//end class

--- a/CakePHP/Sniffs/Methods/MethodDeclarationSniff.php
+++ b/CakePHP/Sniffs/Methods/MethodDeclarationSniff.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * PSR2_Sniffs_Methods_MethodDeclarationSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+if (class_exists('PHP_CodeSniffer_Standards_AbstractScopeSniff', true) === false) {
+    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractScopeSniff not found');
+}
+
+/**
+ * PSR2_Sniffs_Methods_MethodDeclarationSniff.
+ *
+ * Checks that the method declaration is correct.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class CakePHP_Sniffs_Methods_MethodDeclarationSniff extends PHP_CodeSniffer_Standards_AbstractScopeSniff
+{
+
+
+    /**
+     * Constructs a Squiz_Sniffs_Scope_MethodScopeSniff.
+     */
+    public function __construct()
+    {
+        parent::__construct(array(T_CLASS, T_INTERFACE), array(T_FUNCTION));
+
+    }//end __construct()
+
+
+    /**
+     * Processes the function tokens within the class.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file where this token was found.
+     * @param int                  $stackPtr  The position where the token was found.
+     * @param int                  $currScope The current scope opener token.
+     *
+     * @return void
+     */
+    protected function processTokenWithinScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $currScope)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $methodName = $phpcsFile->getDeclarationName($stackPtr);
+        if ($methodName === null) {
+            // Ignore closures.
+            return;
+        }
+
+        $visibility = 0;
+        $static     = 0;
+        $abstract   = 0;
+        $final      = 0;
+
+        $find   = PHP_CodeSniffer_Tokens::$methodPrefixes;
+        $find[] = T_WHITESPACE;
+        $prev   = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
+
+        $prefix = $stackPtr;
+        while (($prefix = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$methodPrefixes, ($prefix - 1), $prev)) !== false) {
+            switch ($tokens[$prefix]['code']) {
+            case T_STATIC:
+                $static = $prefix;
+                break;
+            case T_ABSTRACT:
+                $abstract = $prefix;
+                break;
+            case T_FINAL:
+                $final = $prefix;
+                break;
+            default:
+                $visibility = $prefix;
+                break;
+            }
+        }
+
+        $fixes = array();
+
+        if ($visibility !== 0 && $final > $visibility) {
+            $error = 'The final declaration must precede the visibility declaration';
+            $fix   = $phpcsFile->addFixableError($error, $final, 'FinalAfterVisibility');
+            if ($fix === true) {
+                $fixes[$final]       = '';
+                $fixes[($final + 1)] = '';
+                if (isset($fixes[$visibility]) === true) {
+                    $fixes[$visibility] = 'final '.$fixes[$visibility];
+                } else {
+                    $fixes[$visibility] = 'final '.$tokens[$visibility]['content'];
+                }
+            }
+        }
+
+        if ($visibility !== 0 && $abstract > $visibility) {
+            $error = 'The abstract declaration must precede the visibility declaration';
+            $fix   = $phpcsFile->addFixableError($error, $abstract, 'AbstractAfterVisibility');
+            if ($fix === true) {
+                $fixes[$abstract]       = '';
+                $fixes[($abstract + 1)] = '';
+                if (isset($fixes[$visibility]) === true) {
+                    $fixes[$visibility] = 'abstract '.$fixes[$visibility];
+                } else {
+                    $fixes[$visibility] = 'abstract '.$tokens[$visibility]['content'];
+                }
+            }
+        }
+
+        if ($static !== 0 && $static < $visibility) {
+            $error = 'The static declaration must come after the visibility declaration';
+            $fix   = $phpcsFile->addFixableError($error, $static, 'StaticBeforeVisibility');
+            if ($fix === true) {
+                $fixes[$static]       = '';
+                $fixes[($static + 1)] = '';
+                if (isset($fixes[$visibility]) === true) {
+                    $fixes[$visibility] = $fixes[$visibility].' static';
+                } else {
+                    $fixes[$visibility] = $tokens[$visibility]['content'].' static';
+                }
+            }
+        }
+
+        // Batch all the fixes together to reduce the possibility of conflicts.
+        if (empty($fixes) === false) {
+            $phpcsFile->fixer->beginChangeset();
+            foreach ($fixes as $stackPtr => $content) {
+                $phpcsFile->fixer->replaceToken($stackPtr, $content);
+            }
+
+            $phpcsFile->fixer->endChangeset();
+        }
+
+    }//end processTokenWithinScope()
+
+
+}//end class

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -6,7 +6,10 @@
  <exclude-pattern>*/Config/*.ini.php</exclude-pattern>
  <exclude-pattern>/*/tmp/</exclude-pattern>
 
- <rule ref="PSR2"/>
+ <rule ref="PSR2">
+  <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
+  <exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>
+ </rule>
 
  <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
 


### PR DESCRIPTION
PSR2.Methods.MethodDeclaration.Underscore and PSR2.Methods.MethodDeclaration.Underscore
are replaced by our own sniffs to avoid warnings for protected methods and properties with
underscore prefix but still have other checks done.

Currently you have to ignore all warnings to get phpcs builds to pass on travis. But that means we also miss out on other fixable issues. Since we are close to RC and removing the underscore prefixes is not feasible, I copied the relevant sniffs from PSR2 and removed the code which throw that warning for methods and properties.
