### PR TITLE
Don't show warnings for properties and methods names with underscore pre...

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -8,6 +8,14 @@
 
  <rule ref="PSR2"/>
 
+ <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
+  <severity>0</severity>
+ </rule>
+
+ <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
+  <severity>0</severity>
+ </rule>
+
  <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
 
  <rule ref="Squiz.Classes.LowercaseClassKeywords"/>

--- a/CakePHP/tests/files/class_underscore_prefix_pass.php
+++ b/CakePHP/tests/files/class_underscore_prefix_pass.php
@@ -1,0 +1,12 @@
+<?php
+
+class ClassWithUndercore extends Object
+{
+
+    protected $_someProp;
+
+    protected function _someFunc()
+    {
+        // code here
+    }
+}


### PR DESCRIPTION
...fix.
