### PR TITLE
Relax docblock indentation for flat files

### DIFF
--- a/CakePHP/Sniffs/Commenting/DocBlockAlignmentSniff.php
+++ b/CakePHP/Sniffs/Commenting/DocBlockAlignmentSniff.php
@@ -52,9 +52,10 @@ class CakePHP_Sniffs_Commenting_DocBlockAlignmentSniff implements PHP_CodeSniffe
             T_CONST
         );
         $allTokens = array_merge($leftWall, $oneIndentation);
-
+        $notFlatFile = $phpcsFile->findNext(T_NAMESPACE, 0, null);
         $next = $phpcsFile->findNext($allTokens, $stackPtr + 1, null);
-        if ($next) {
+
+        if ($next && $notFlatFile) {
             $notWalled = (in_array($tokens[$next]['code'], $leftWall) && $tokens[$stackPtr]['column'] !== 1);
             $notIndented = (in_array($tokens[$next]['code'], $oneIndentation) && $tokens[$stackPtr]['column'] !== 5);
             if ($notWalled || $notIndented) {

--- a/CakePHP/tests/files/docblock_align_flat_pass.php
+++ b/CakePHP/tests/files/docblock_align_flat_pass.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Hello World.
+ *
+ * This is a description.
+ */
+$things = 'fun';
+
+/**
+ * I'm static.
+ */
+Foo::bar($things);
+
+$anotherThing = 'what';
+
+/**
+ * What happens with If's?
+ *
+ */
+if ($anotherThing !== 'notfun') {
+    $anotherThing = 'Oh no.';
+}
+
+$hello = 'world';


### PR DESCRIPTION
If a file doesn't contain a namespace, consider it a flat file, and relax the docblock indentation rules.
Refs: https://github.com/cakephp/cakephp-codesniffer/pull/119#issuecomment-73640822