### PR TITLE
enforce short array usage

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -42,6 +42,7 @@
  </rule>
 
  <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
+ <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
  <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "source": "https://github.com/cakephp/cakephp-codesniffer"
     },
     "require": {
-        "squizlabs/php_codesniffer": "2.*"
+        "squizlabs/php_codesniffer": "^2.3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*"


### PR DESCRIPTION
as it's now natively proposed squizlabs/php_codesniffer