### PR TITLE
Remove underscore requirement for protected/private methods

### DIFF
--- a/CakePHP/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/CakePHP/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -115,23 +115,9 @@ class CakePHP_Sniffs_NamingConventions_ValidFunctionNameSniff extends PHP_CodeSn
 				return;
 			}
 		} elseif ($isPrivate === true) {
-			if (substr($methodName, 0, 2) !== '__') {
-				$error = 'Private method name "%s" must be prefixed with 2 underscores';
-				$phpcsFile->addError($error, $stackPtr, 'PrivateNoUnderscore', $errorData);
-				return;
-			} else {
-				$filename = $phpcsFile->getFilename();
-				if (strpos($filename, '/lib/Cake/') === true) {
-					$warning = 'Private method name "%s" in CakePHP core is discouraged';
-					$phpcsFile->addWarning($warning, $stackPtr, 'PrivateMethodInCore', $errorData);
-				}
-			}
-		} else {
-			if ($methodName[0] !== '_' || substr($methodName, 0, 2) === '__') {
-				$error = 'Protected method name "%s" must be prefixed with one underscore';
-				$phpcsFile->addError($error, $stackPtr, 'ProtectedNoUnderscore', $errorData);
-				return;
-			}
+			$filename = $phpcsFile->getFilename();
+			$warning = 'Private method name "%s" in CakePHP core is discouraged';
+			$phpcsFile->addWarning($warning, $stackPtr, 'PrivateMethodInCore', $errorData);
 		}
 	}
 

--- a/CakePHP/tests/files/class_underscore_prefix_pass.php
+++ b/CakePHP/tests/files/class_underscore_prefix_pass.php
@@ -15,4 +15,14 @@ class ClassWithUndercore extends Object
     {
         // code here
     }
+
+    /**
+     * [noUnderscorePrefix description]
+     *
+     * @return void
+     */
+    protected function noUnderscorePrefix()
+    {
+        // code here
+    }
 }

--- a/CakePHP/tests/files/operator_spacing_pass.php
+++ b/CakePHP/tests/files/operator_spacing_pass.php
@@ -1,7 +1,7 @@
 <?php
 $foo = -1;
 
-switch($foo) {
+switch ($foo) {
     case -1:
         break;
     case 'negative':


### PR DESCRIPTION
This removes the underscore prefix requirement for protected and private methods. This will allow us to run the sniffer against new repos/plugins that have dropped this convention. Meanwhile, we can be conscious about any proposed underscore prefix changes in Cake core.