### PR TITLE
Readded check for core

### DIFF
--- a/CakePHP/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/CakePHP/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -114,7 +114,7 @@ class CakePHP_Sniffs_NamingConventions_ValidFunctionNameSniff extends PHP_CodeSn
 			if (substr($className, -4) === 'Task') {
 				return;
 			}
-		} elseif ($isPrivate === true) {
+		} elseif ($isPrivate === true && strpos($phpcsFile->getFilename(), '/lib/cake') === true) {
 			$filename = $phpcsFile->getFilename();
 			$warning = 'Private method name "%s" in CakePHP core is discouraged';
 			$phpcsFile->addWarning($warning, $stackPtr, 'PrivateMethodInCore', $errorData);


### PR DESCRIPTION
CakePHP phpcs with CakePHP standards fires CakePHP.NamingConventions.ValidFunctionName.PrivateMethodInCore on all my private methods. 
Problem comes from the removed /lib/cake, so now everything is core.

I re-added the check in this PR