### PR TITLE
Fix fixer code in "BlankLineBeforeReturn" sniff.

### DIFF
--- a/CakePHP/Sniffs/Formatting/BlankLineBeforeReturnSniff.php
+++ b/CakePHP/Sniffs/Formatting/BlankLineBeforeReturnSniff.php
@@ -69,7 +69,7 @@ class CakePHP_Sniffs_Formatting_BlankLineBeforeReturnSniff implements PHP_CodeSn
             );
             if ($fix === true) {
                 $phpcsFile->fixer->beginChangeset();
-                $phpcsFile->fixer->addContentBefore($stackPtr, "\n\n");
+                $phpcsFile->fixer->addNewlineBefore($stackPtr - 1);
                 $phpcsFile->fixer->endChangeset();
             }
         }


### PR DESCRIPTION
This correctly does what c0c04662d2543e2d2f0633013381eafb0ee7ea61 intended. I actually tested it on Crud plugin and it yielded correct results.