### PR TITLE
Relax more rules and add Composer scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - composer install --prefer-source
 
 script:
-  - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION = 7.1 ]]; then composer add-standard; composer increase-severity; vendor/bin/phpunit --coverage-clover=clover.xml; fi
+  - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION = 7.1 ]]; then composer run-script test-coverage --timeout=0; fi
   - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION != 7.1 ]]; then composer test; fi
   - if [[ $PHPCS = 1 ]]; then composer cs-check; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,14 @@ matrix:
 before_script:
   - composer self-update
   - composer install --prefer-source
-  - vendor/bin/phpcs --config-set installed_paths $(pwd)
 
 script:
-  - if [[ $PHPCS != 1 ]]; then sed -i.bak "s/<severity>0<\/severity>//" CakePHP/ruleset.xml; fi
-  - sed -i.bak "s/<exclude-pattern>\*\/tests\/\*<\/exclude-pattern>//" CakePHP/ruleset.xml
-  - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION = 7.1 ]]; then vendor/bin/phpunit --coverage-clover=clover.xml; fi
-  - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION != 7.1 ]]; then vendor/bin/phpunit; fi
-  - if [[ $PHPCS = 1 ]]; then vendor/bin/phpcs -p --extensions=php --standard=CakePHP ./CakePHP; fi
+  - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION = 7.1 ]]; then composer increase-severity; vendor/bin/phpunit --coverage-clover=clover.xml; fi
+  - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION != 7.1 ]]; then composer test; fi
+  - if [[ $PHPCS = 1 ]]; then composer cs-check; fi
 
 after_success:
-  - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION = 7.0 ]]; then bash <(curl -s https://codecov.io/bash); fi
+  - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION = 7.1 ]]; then bash <(curl -s https://codecov.io/bash); fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - composer install --prefer-source
 
 script:
-  - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION = 7.1 ]]; then composer increase-severity; vendor/bin/phpunit --coverage-clover=clover.xml; fi
+  - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION = 7.1 ]]; then composer add-standard; composer increase-severity; vendor/bin/phpunit --coverage-clover=clover.xml; fi
   - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION != 7.1 ]]; then composer test; fi
   - if [[ $PHPCS = 1 ]]; then composer cs-check; fi
 

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -18,7 +18,7 @@
  <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
   <severity>0</severity>
  </rule>
- <rule ref ="Squiz.NamingConventions.ValidFunctionName.PublicUnderscore">
+ <rule ref="Squiz.NamingConventions.ValidFunctionName.PublicUnderscore">
   <severity>0</severity>
  </rule>
  <rule ref ="PEAR.NamingConventions.ValidFunctionName.PublicUnderscore">

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -32,13 +32,16 @@
  <rule ref ="Zend.NamingConventions.ValidVariableName.ContainsNumbers">
   <severity>0</severity>
  </rule>
+ <rule ref ="Zend.NamingConventions.ValidVariableName.StringVarContainsNumbers">
+  <severity>0</severity>
+ </rule>
+ <rule ref ="Zend.NamingConventions.ValidVariableName.MemberVarContainsNumbers">
+  <severity>0</severity>
+ </rule>
  <rule ref ="Zend.NamingConventions.ValidVariableName.NotCamelCaps">
   <severity>0</severity>
  </rule>
  <rule ref ="Zend.NamingConventions.ValidVariableName.MemberVarNotCamelCaps">
-  <severity>0</severity>
- </rule>
- <rule ref ="Zend.NamingConventions.ValidVariableName.ContainsNumbers">
   <severity>0</severity>
  </rule>
 

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -21,27 +21,27 @@
  <rule ref="Squiz.NamingConventions.ValidFunctionName.PublicUnderscore">
   <severity>0</severity>
  </rule>
- <rule ref ="PEAR.NamingConventions.ValidFunctionName.PublicUnderscore">
+ <rule ref="PEAR.NamingConventions.ValidFunctionName.PublicUnderscore">
   <severity>0</severity>
  </rule>
- <rule ref ="Zend.NamingConventions.ValidVariableName">
+ <rule ref="Zend.NamingConventions.ValidVariableName">
  </rule>
- <rule ref ="Zend.NamingConventions.ValidVariableName.PrivateNoUnderscore">
+ <rule ref="Zend.NamingConventions.ValidVariableName.PrivateNoUnderscore">
   <severity>0</severity>
  </rule>
- <rule ref ="Zend.NamingConventions.ValidVariableName.ContainsNumbers">
+ <rule ref="Zend.NamingConventions.ValidVariableName.ContainsNumbers">
   <severity>0</severity>
  </rule>
- <rule ref ="Zend.NamingConventions.ValidVariableName.StringVarContainsNumbers">
+ <rule ref="Zend.NamingConventions.ValidVariableName.StringVarContainsNumbers">
   <severity>0</severity>
  </rule>
- <rule ref ="Zend.NamingConventions.ValidVariableName.MemberVarContainsNumbers">
+ <rule ref="Zend.NamingConventions.ValidVariableName.MemberVarContainsNumbers">
   <severity>0</severity>
  </rule>
- <rule ref ="Zend.NamingConventions.ValidVariableName.NotCamelCaps">
+ <rule ref="Zend.NamingConventions.ValidVariableName.NotCamelCaps">
   <severity>0</severity>
  </rule>
- <rule ref ="Zend.NamingConventions.ValidVariableName.MemberVarNotCamelCaps">
+ <rule ref="Zend.NamingConventions.ValidVariableName.MemberVarNotCamelCaps">
   <severity>0</severity>
  </rule>
 

--- a/composer.json
+++ b/composer.json
@@ -30,27 +30,19 @@
         }
     },
     "scripts": {
-        "increaseSeverity": "sed -i '' 's/<severity>0<\\/severity>/<!--<severity>0<\\/severity>-->/' CakePHP/ruleset.xml",
-        "includeTestsDirectory": "sed -i '' 's/<exclude-pattern>\\*\\/tests\\/\\*<\\/exclude-pattern>/<!--<exclude-pattern>\\*\\/tests\\/\\*<\\/exclude-pattern>-->/' CakePHP/ruleset.xml",
-        "resetRuleset": [
-            "sed -i '' 's/<!--<severity>0<\\/severity>-->/<severity>0<\\/severity>/' CakePHP/ruleset.xml",
-            "sed -i '' 's/<!--<exclude-pattern>\\*\\/tests\\/\\*<\\/exclude-pattern>-->/<exclude-pattern>\\*\\/tests\\/\\*<\\/exclude-pattern>/' CakePHP/ruleset.xml"
+        "increase-severity": "sed -i.bak 's/<severity>0<\\/severity>/<!--<severity>0<\\/severity>-->/' CakePHP/ruleset.xml",
+        "reset-ruleset": [
+            "sed -i.bak 's/<!--<severity>0<\\/severity>-->/<severity>0<\\/severity>/' CakePHP/ruleset.xml",
+            "rm -f CakePHP/ruleset.xml.bak"
         ],
-        "addStandard" : "phpcs --config-set installed_paths $(pwd)",
+        "add-standard" : "phpcs --config-set installed_paths $(pwd)",
         "test": [
-          "@increaseSeverity",
+          "@add-standard",
+          "@increase-severity",
           "phpunit",
-          "@resetRuleset"
+          "@reset-ruleset"
         ],
-        "cs-check": [
-            "@addStandard",
-            "phpcs --colors -p --extensions=php --standard=CakePHP ./CakePHP",
-            "@resetRuleset"
-        ],
-        "cs-fix":  [
-            "@addStandard",
-            "phpcbf --colors --extensions=php --standard=CakePHP ./CakePHP",
-            "@resetRuleset"
-        ]
+        "cs-check": "phpcs --colors -p --extensions=php --standard=CakePHP ./CakePHP",
+        "cs-fix": "phpcbf --colors --extensions=php --standard=CakePHP ./CakePHP"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,12 @@
           "phpunit",
           "@reset-ruleset"
         ],
+        "test-coverage": [
+          "@add-standard",
+          "@increase-severity",
+          "phpunit --coverage-clover=clover.xml",
+          "@reset-ruleset"
+        ],
         "cs-check": "phpcs --colors -p --extensions=php --standard=CakePHP ./CakePHP",
         "cs-fix": "phpcbf --colors --extensions=php --standard=CakePHP ./CakePHP"
     }

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,29 @@
         "psr-4": {
             "CakePHP\\": "CakePHP"
         }
+    },
+    "scripts": {
+        "increaseSeverity": "sed -i '' 's/<severity>0<\\/severity>/<!--<severity>0<\\/severity>-->/' CakePHP/ruleset.xml",
+        "includeTestsDirectory": "sed -i '' 's/<exclude-pattern>\\*\\/tests\\/\\*<\\/exclude-pattern>/<!--<exclude-pattern>\\*\\/tests\\/\\*<\\/exclude-pattern>-->/' CakePHP/ruleset.xml",
+        "resetRuleset": [
+            "sed -i '' 's/<!--<severity>0<\\/severity>-->/<severity>0<\\/severity>/' CakePHP/ruleset.xml",
+            "sed -i '' 's/<!--<exclude-pattern>\\*\\/tests\\/\\*<\\/exclude-pattern>-->/<exclude-pattern>\\*\\/tests\\/\\*<\\/exclude-pattern>/' CakePHP/ruleset.xml"
+        ],
+        "addStandard" : "phpcs --config-set installed_paths $(pwd)",
+        "test": [
+          "@increaseSeverity",
+          "phpunit",
+          "@resetRuleset"
+        ],
+        "cs-check": [
+            "@addStandard",
+            "phpcs --colors -p --extensions=php --standard=CakePHP ./CakePHP",
+            "@resetRuleset"
+        ],
+        "cs-fix":  [
+            "@addStandard",
+            "phpcbf --colors --extensions=php --standard=CakePHP ./CakePHP",
+            "@resetRuleset"
+        ]
     }
 }


### PR DESCRIPTION
I've pointed some more rules that needed to be relaxed since we are using Zend NamingConvention Sniff while running the CS against Cakephp core.

@ADmad I've added Composer scripts has discussed, I hope that this is it what you had in mind more or less.