### PR TITLE
Ignore the inheritDoc tag using insensitive case

### DIFF
--- a/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
@@ -60,7 +60,7 @@ class CakePHP_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Comment
         $start = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr - 1);
         $end = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, $start);
         $content = $phpcsFile->getTokensAsString($start, ($end - $start));
-        return preg_match('#{@inheritDoc}#', $content) === 1;
+        return preg_match('/{@inheritDoc}/i', $content) === 1;
     } // end isInheritDoc()
 
     /**


### PR DESCRIPTION
Most of the times PhpStorms autocompletes the {@inhertidoc} with all small caps.