### PR TITLE
Allow doc comments inside classes to be at any indentation level

### DIFF
--- a/CakePHP/Sniffs/Commenting/DocBlockAlignmentSniff.php
+++ b/CakePHP/Sniffs/Commenting/DocBlockAlignmentSniff.php
@@ -44,19 +44,12 @@ class DocBlockAlignmentSniff implements Sniff
             T_TRAIT,
             T_USE,
         ];
-        $oneIndentation = [
-            T_FUNCTION,
-            T_VARIABLE,
-            T_CONST,
-        ];
-        $allTokens = array_merge($leftWall, $oneIndentation);
         $notFlatFile = $phpcsFile->findNext(T_NAMESPACE, 0);
-        $next = $phpcsFile->findNext($allTokens, $stackPtr + 1);
+        $next = $phpcsFile->findNext($leftWall, $stackPtr + 1);
 
         if ($next && $notFlatFile) {
             $notWalled = (in_array($tokens[$next]['code'], $leftWall) && $tokens[$stackPtr]['column'] !== 1);
-            $notIndented = (in_array($tokens[$next]['code'], $oneIndentation) && $tokens[$stackPtr]['column'] !== 5);
-            if ($notWalled || $notIndented) {
+            if ($notWalled) {
                 $phpcsFile->addError('Expected docblock to be aligned with code.', $stackPtr, 'NotAllowed');
             }
         }

--- a/CakePHP/Tests/Commenting/DocBlockAlignmentUnitTest.php
+++ b/CakePHP/Tests/Commenting/DocBlockAlignmentUnitTest.php
@@ -16,8 +16,6 @@ class DocBlockAlignmentUnitTest extends AbstractSniffUnitTest
                 return [
                     2 => 1,
                     7 => 1,
-                    14 => 1,
-                    21 => 1,
                 ];
 
             default:


### PR DESCRIPTION
Facilitates inline doc comments (like `/** @var $foo Bar */` to suppress "`$foo->getBar()` method is not defined" warnings in IDEs) and addresses bug acknowledged in discussion at https://github.com/cakephp/cakephp-codesniffer/issues/172#issuecomment-261802729

This does not enforce inline doc comments being indented appropriately, which should be added to this sniff at some point.