### PR TITLE
Bump PHP requirement to at least 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "source": "https://github.com/cakephp/cakephp-codesniffer"
     },
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.6",
         "squizlabs/php_codesniffer": "^3.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
It's rather pointless to support PHP versions below the framework's minimum requriement
https://book.cakephp.org/3.0/en/installation.html#requirements