### PR TITLE
Allow php codesniffer 3.2

### DIFF
--- a/CakePHP/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/CakePHP/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -41,9 +41,9 @@ class FunctionSpacingSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         /*
-			Check the number of blank lines
-			after the function.
-		*/
+            Check the number of blank lines
+            after the function.
+        */
         if (isset($tokens[$stackPtr]['scope_closer']) === false) {
             // Must be an interface method, so the closer is the semi-colon.
             $closer = $phpcsFile->findNext(T_SEMICOLON, $stackPtr);
@@ -77,9 +77,9 @@ class FunctionSpacingSniff implements Sniff
         }
 
         /*
-			Check the number of blank lines
-			before the function.
-		*/
+            Check the number of blank lines
+            before the function.
+        */
 
         $prevLineToken = null;
         for ($i = $stackPtr; $i > 0; $i--) {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "squizlabs/php_codesniffer": "~3.0.0"
+        "squizlabs/php_codesniffer": "^3.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "<6.0"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit>
+<phpunit bootstrap="vendor/squizlabs/php_codesniffer/tests/bootstrap.php">
     <testsuites>
         <testsuite name="CakePHP CodeSniffer Test Suite">
             <file>./vendor/squizlabs/php_codesniffer/tests/AllTests.php</file>


### PR DESCRIPTION
PHP Codesniffer 3.2 release notes says that in order to test you should include their bootstrap, so this PR does that.

This allows to use new options like [Ignoring Parts of a File](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file). for example the namespace sniff in migrations, also could be in bake templates until cakephp/migrations#213 gets resolved
```php
<?php
// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
use Migrations\AbstractMigration;

class CreatePosts extends AbstractMigration
{
// ....
}
```