### PR TITLE
Don't add spaces around declare() arguments.

### DIFF
--- a/CakePHP/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/CakePHP/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -57,6 +57,7 @@ class OperatorSpacingSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Skip default values in function declarations.
+        // and declare statements
         if ($tokens[$stackPtr]['code'] === T_EQUAL
             || $tokens[$stackPtr]['code'] === T_MINUS
         ) {
@@ -65,7 +66,9 @@ class OperatorSpacingSniff implements Sniff
                 $bracket = array_pop($parenthesis);
                 if (isset($tokens[$bracket]['parenthesis_owner']) === true) {
                     $function = $tokens[$bracket]['parenthesis_owner'];
-                    if ($tokens[$function]['code'] === T_FUNCTION) {
+                    if ($tokens[$function]['code'] === T_FUNCTION ||
+                        $tokens[$function]['code'] === T_DECLARE
+                    ) {
                         return;
                     }
                 }

--- a/CakePHP/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
+++ b/CakePHP/Tests/WhiteSpace/OperatorSpacingUnitTest.inc
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 $ten =10 * 2;
 $ten= -10 * 2;
 $ten = 10/-2;

--- a/CakePHP/Tests/WhiteSpace/OperatorSpacingUnitTest.php
+++ b/CakePHP/Tests/WhiteSpace/OperatorSpacingUnitTest.php
@@ -12,12 +12,12 @@ class OperatorSpacingUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            2 => 1,
             3 => 1,
-            4 => 2,
-            5 => 1,
+            4 => 1,
+            5 => 2,
             6 => 1,
-            7 => 2,
+            7 => 1,
+            8 => 2,
         ];
     }
 

--- a/CakePHP/Tests/WhiteSpace/OperatorSpacingunitTest.inc.fixed
+++ b/CakePHP/Tests/WhiteSpace/OperatorSpacingunitTest.inc.fixed
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 $ten = 10 * 2;
 $ten = -10 * 2;
 $ten = 10 / -2;


### PR DESCRIPTION
PSR12 recommends `declare(strict_types=1)` not `declare(strict_types = 1)`