### PR TITLE
Explain standard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,13 @@
 This code works with [squizlabs/php_codesniffer](https://github.com/squizlabs/PHP_CodeSniffer)
 and checks code against the coding standards used in CakePHP.
 
+This sniffer package follows [PSR-2](http://www.php-fig.org/psr/psr-2/) completely and ships with a lot of additional fixers on top.
+
+[List of included sniffs](/docs)
+
 :warning: The `master` branch contains codesniffer rules that are based on the
-PSR2 standard. If you want to check against the historical CakePHP coding
+PSR2 standard. Ther `next` branch is for CakePHP 4.0+ and requires PHP 7.1+. 
+If you want to check against the historical CakePHP coding
 standard use any of the `1.x` releases.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This sniffer package follows [PSR-2](http://www.php-fig.org/psr/psr-2/) complete
 [List of included sniffs](/docs)
 
 :warning: The `master` branch contains codesniffer rules that are based on the
-PSR2 standard. Ther `next` branch is for CakePHP 4.0+ and requires PHP 7.1+. 
+PSR2 standard. The `next` branch is for CakePHP 4.0+ and requires PHP 7.1+. 
 If you want to check against the historical CakePHP coding
 standard use any of the `1.x` releases.
 

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,8 @@
           "@reset-ruleset"
         ],
         "cs-check": "phpcs --colors -p --exclude=SlevomatCodingStandard.TypeHints.DeclareStrictTypes --standard=CakePHP ./CakePHP/Sniffs",
-        "cs-fix": "phpcbf --colors -p --exclude=SlevomatCodingStandard.TypeHints.DeclareStrictTypes --standard=CakePHP ./CakePHP/Sniffs"
+        "cs-fix": "phpcbf --colors -p --exclude=SlevomatCodingStandard.TypeHints.DeclareStrictTypes --standard=CakePHP ./CakePHP/Sniffs",
+        "docs": "php docs/generate.php",
+        "explain": "phpcs -e --standard=CakePHP"
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -142,4 +142,4 @@ Squiz (28 sniffs)
 
 Zend (1 sniff)
 ---------------
-- Zend.NamingConventions.ValidVariableName;
+- Zend.NamingConventions.ValidVariableName

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,145 @@
+# CakePHP Code Sniffer
+
+
+The CakePHP standard contains 114 sniffs
+
+CakePHP (16 sniffs)
+-------------------
+- CakePHP.Commenting.DocBlockAlignment
+- CakePHP.Commenting.FunctionComment
+- CakePHP.ControlStructures.ControlStructures
+- CakePHP.ControlStructures.ElseIfDeclaration
+- CakePHP.ControlStructures.WhileStructures
+- CakePHP.Formatting.BlankLineBeforeReturn
+- CakePHP.Functions.ClosureDeclaration
+- CakePHP.NamingConventions.ValidFunctionName
+- CakePHP.NamingConventions.ValidTraitName
+- CakePHP.PHP.DisallowShortOpenTag
+- CakePHP.WhiteSpace.EmptyLines
+- CakePHP.WhiteSpace.FunctionCallSpacing
+- CakePHP.WhiteSpace.FunctionClosingBraceSpace
+- CakePHP.WhiteSpace.FunctionOpeningBraceSpace
+- CakePHP.WhiteSpace.FunctionSpacing
+- CakePHP.WhiteSpace.TabAndSpace
+
+Generic (25 sniffs)
+-------------------
+- Generic.Arrays.DisallowLongArraySyntax
+- Generic.CodeAnalysis.ForLoopShouldBeWhileLoop
+- Generic.CodeAnalysis.ForLoopWithTestFunctionCall
+- Generic.CodeAnalysis.JumbledIncrementer
+- Generic.CodeAnalysis.UnconditionalIfStatement
+- Generic.CodeAnalysis.UnnecessaryFinalModifier
+- Generic.Commenting.Todo
+- Generic.ControlStructures.InlineControlStructure
+- Generic.Files.ByteOrderMark
+- Generic.Files.LineEndings
+- Generic.Files.LineLength
+- Generic.Formatting.DisallowMultipleStatements
+- Generic.Formatting.NoSpaceAfterCast
+- Generic.Functions.FunctionCallArgumentSpacing
+- Generic.NamingConventions.CamelCapsFunctionName
+- Generic.NamingConventions.UpperCaseConstantName
+- Generic.PHP.DeprecatedFunctions
+- Generic.PHP.DisallowShortOpenTag
+- Generic.PHP.ForbiddenFunctions
+- Generic.PHP.LowerCaseConstant
+- Generic.PHP.LowerCaseKeyword
+- Generic.PHP.LowerCaseType
+- Generic.PHP.NoSilencedErrors
+- Generic.WhiteSpace.DisallowTabIndent
+- Generic.WhiteSpace.ScopeIndent
+
+PEAR (3 sniffs)
+---------------
+- PEAR.Functions.ValidDefaultValue
+- PEAR.NamingConventions.ValidClassName
+- PEAR.NamingConventions.ValidFunctionName
+
+PSR1 (3 sniffs)
+---------------
+- PSR1.Classes.ClassDeclaration
+- PSR1.Files.SideEffects
+- PSR1.Methods.CamelCapsMethodName
+
+PSR12 (4 sniffs)
+----------------
+- PSR12.Classes.ClassInstantiation
+- PSR12.Keywords.ShortFormTypeKeywords
+- PSR12.Namespaces.CompoundNamespaceDepth
+- PSR12.Operators.OperatorSpacing
+
+PSR2 (12 sniffs)
+----------------
+- PSR2.Classes.ClassDeclaration
+- PSR2.Classes.PropertyDeclaration
+- PSR2.ControlStructures.ControlStructureSpacing
+- PSR2.ControlStructures.ElseIfDeclaration
+- PSR2.ControlStructures.SwitchDeclaration
+- PSR2.Files.ClosingTag
+- PSR2.Files.EndFileNewline
+- PSR2.Methods.FunctionCallSignature
+- PSR2.Methods.FunctionClosingBrace
+- PSR2.Methods.MethodDeclaration
+- PSR2.Namespaces.NamespaceDeclaration
+- PSR2.Namespaces.UseDeclaration
+
+SlevomatCodingStandard (22 sniffs)
+----------------------------------
+- SlevomatCodingStandard.Arrays.TrailingArrayComma
+- SlevomatCodingStandard.Classes.ClassConstantVisibility
+- SlevomatCodingStandard.Classes.UnusedPrivateElements
+- SlevomatCodingStandard.ControlStructures.AssignmentInCondition
+- SlevomatCodingStandard.ControlStructures.DisallowYodaComparison
+- SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses
+- SlevomatCodingStandard.ControlStructures.NewWithParentheses
+- SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator
+- SlevomatCodingStandard.Exceptions.DeadCatch
+- SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses
+- SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation
+- SlevomatCodingStandard.Namespaces.NamespaceDeclaration
+- SlevomatCodingStandard.Namespaces.UnusedUses
+- SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash
+- SlevomatCodingStandard.Namespaces.UseFromSameNamespace
+- SlevomatCodingStandard.PHP.TypeCast
+- SlevomatCodingStandard.TypeHints.DeclareStrictTypes
+- SlevomatCodingStandard.TypeHints.LongTypeHints
+- SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue
+- SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing
+- SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
+- SlevomatCodingStandard.Types.EmptyLinesAroundTypeBraces
+
+Squiz (28 sniffs)
+-----------------
+- Squiz.Arrays.ArrayBracketSpacing
+- Squiz.Classes.LowercaseClassKeywords
+- Squiz.Classes.ValidClassName
+- Squiz.Commenting.DocCommentAlignment
+- Squiz.ControlStructures.ControlSignature
+- Squiz.ControlStructures.ForEachLoopDeclaration
+- Squiz.ControlStructures.ForLoopDeclaration
+- Squiz.ControlStructures.LowercaseDeclaration
+- Squiz.Functions.FunctionDeclaration
+- Squiz.Functions.FunctionDeclarationArgumentSpacing
+- Squiz.Functions.LowercaseFunctionKeywords
+- Squiz.Functions.MultiLineFunctionDeclaration
+- Squiz.NamingConventions.ValidFunctionName
+- Squiz.Operators.ValidLogicalOperators
+- Squiz.PHP.DisallowSizeFunctionsInLoops
+- Squiz.PHP.Eval
+- Squiz.PHP.NonExecutableCode
+- Squiz.Scope.MemberVarScope
+- Squiz.Scope.MethodScope
+- Squiz.Scope.StaticThisUsage
+- Squiz.WhiteSpace.CastSpacing
+- Squiz.WhiteSpace.ControlStructureSpacing
+- Squiz.WhiteSpace.LanguageConstructSpacing
+- Squiz.WhiteSpace.LogicalOperatorSpacing
+- Squiz.WhiteSpace.ScopeClosingBrace
+- Squiz.WhiteSpace.ScopeKeywordSpacing
+- Squiz.WhiteSpace.SemicolonSpacing
+- Squiz.WhiteSpace.SuperfluousWhitespace
+
+Zend (1 sniff)
+---------------
+- Zend.NamingConventions.ValidVariableName;

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -1,0 +1,27 @@
+#!/usr/bin/env php
+<?php
+$phar = file_exists(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'composer.phar');
+$command = ($phar ? 'php composer.phar' : 'composer') . ' explain';
+
+exec($command, $output, $ret);
+if ($ret !== 0) {
+    exit('Invalid execution. Run from ROOT after composer install etc as `composer docs`.');
+}
+
+foreach ($output as &$row) {
+    $row = str_replace('  ', '- ', $row);
+}
+unset($row);
+
+$content = implode(PHP_EOL, $output);
+
+$content = <<<TEXT
+# CakePHP Code Sniffer
+
+$content;
+TEXT;
+
+$file = __DIR__ . DIRECTORY_SEPARATOR . 'README.md';
+
+file_put_contents($file, $content);
+exit($ret);

--- a/docs/generate.php
+++ b/docs/generate.php
@@ -18,7 +18,7 @@ $content = implode(PHP_EOL, $output);
 $content = <<<TEXT
 # CakePHP Code Sniffer
 
-$content;
+$content
 TEXT;
 
 $file = __DIR__ . DIRECTORY_SEPARATOR . 'README.md';


### PR DESCRIPTION
I would like to propose a more verbosely written list of the explained ruleset.
We can easily update it using `composer docs`, just as we do at [Spryker](https://github.com/spryker/code-sniffer/tree/master/docs).

It is super useful to communicate the current included list, as it lists also the inherited ones :)