### PR TITLE
Remove rule for "todo" annotations.

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -87,7 +87,6 @@
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement" />
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier" />
     <rule ref="Squiz.Commenting.DocCommentAlignment" />
-    <rule ref="Generic.Commenting.Todo" />
     <rule ref="Generic.Formatting.NoSpaceAfterCast" />
     <rule ref="Squiz.Operators.ValidLogicalOperators" />
     <rule ref="Generic.PHP.DeprecatedFunctions" />


### PR DESCRIPTION
Doesn't make much sense having this rule when we end up silencing it https://github.com/cakephp/cakephp/blob/8baeda92fbccc426608a2d347ead7f5dfccb5af1/phpcs.xml.dist#L6.

In apps too having "todo"s isn't a bad thing IMO.