### PR TITLE
Add SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -192,6 +192,7 @@
             <property name="linesCountBeforeClosingBrace" value="0" />
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable" />
 
     <!-- All rules in ./Sniffs are included automatically -->
 </ruleset>


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp-codesniffer/issues/226

Useful to prevent https://github.com/cakephp/cakephp/pull/13000/files