### PR TITLE
Speed up CS run by factor 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
     - php: 7.2
       env: PHPCS=1
 
+before_install:
+  - phpenv config-rm xdebug.ini
+
 before_script:
   - composer install --prefer-source
 
@@ -26,6 +29,10 @@ script:
 
 after_success:
   - if [[ $PHPCS != 1 && $TRAVIS_PHP_VERSION = 7.1 ]]; then bash <(curl -s https://codecov.io/bash); fi
+
+cache:
+    directories:
+        - $HOME/.composer/cache
 
 notifications:
   email: false


### PR DESCRIPTION
We had some performance improvements done recently in Spryker
Our findings I also want to share with u.

Apparently, cs sniffer is > 4x faster without xdebug on.

23s => 10s for master branch since we dont have too many tests yet.

In larger code bases with even more sniffs this is quite noticeable:

- huge repo: 1470s => now only 319s (24 => 5 min!)
- medium repo: 118s => now only 26s (2 => 0.5min)