### PR TITLE
Ignore missing description for "throws" again.

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -65,6 +65,9 @@
     <rule ref="CakePHP.Commenting.FunctionComment.ThrowsNotCapital">
         <severity>0</severity>
     </rule>
+    <rule ref="CakePHP.Commenting.FunctionComment.EmptyThrows">
+        <severity>0</severity>
+    </rule>
     <rule ref="CakePHP.Commenting.FunctionComment.ThrowsNoFullStop">
         <severity>0</severity>
     </rule>


### PR DESCRIPTION
There are too many failures in core for this sniff.