### PR TITLE
Ensure a blank line after declare() statement.

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -183,7 +183,7 @@
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon" />
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes" >
         <properties>
-            <property name="newlinesCountAfterDeclare" value="1" />
+            <property name="newlinesCountAfterDeclare" value="2" />
             <property name="spacesCountAroundEqualsSign" value="0" />
             <property name="newlinesCountBetweenOpenTagAndDeclare" value="1" />
         </properties>


### PR DESCRIPTION
With this change existing code like
```php
declare(strict_types=1);
namespace Foo;
```
will become
```php
declare(strict_types=1);

namespace Foo;
```
and code like 
```php
declare(strict_types=1);
/**
 * docbblock
 */
namespace Foo;
```
will become 
```php
declare(strict_types=1);

/**
 * docbblock
 */
namespace Foo;
```