### PR TITLE
Resolves #253

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,19 @@ and checks code against the coding standards used in CakePHP.
 PSR2 standard. If you want to check against the historical CakePHP coding
 standard use any of the `1.x` releases.
 
+## Which version should I use?
+| CakePHP  | Sniffer |
+| -------- | ------- |
+| 2.x  | 1.0.4  |
+| 3.x  | latest 3.x tag  |
+| 4.x  | latest 4.0.0-beta  |
+
 ## Installation
 
 You should install this codesniffer with composer:
 
-	composer require --dev "cakephp/cakephp-codesniffer"
-	vendor/bin/phpcs --config-set installed_paths /path/to/your/app/vendor/cakephp/cakephp-codesniffer
+    composer require --dev "cakephp/cakephp-codesniffer"
+    vendor/bin/phpcs --config-set installed_paths /path/to/your/app/vendor/cakephp/cakephp-codesniffer
 
 The second command lets `phpcs` know where to find your new sniffs. Ensure that
 you do not overwrite any existing `installed_paths` value.
@@ -27,7 +34,7 @@ you do not overwrite any existing `installed_paths` value.
 Depending on how you installed the code sniffer changes how you run it. If you have
 installed phpcs, and this package with PEAR, you can do the following:
 
-	vendor/bin/phpcs --standard=CakePHP /path/to/code
+    vendor/bin/phpcs --standard=CakePHP /path/to/code
 
 :warning: Warning when these sniffs are installed with composer, ensure that
 you have configured the CodeSniffer `installed_paths` setting.


### PR DESCRIPTION
Added some guidance for developers on which version of cakephp-codesniffer they should be using.

Apologies, but I think PHP Storm has automatically replaced tabs with spaces