### PR TITLE
Fixing a zero offset bug

### DIFF
--- a/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
@@ -397,7 +397,9 @@ class FunctionCommentSniff extends PearFunctionCommentSniff
                         $content .= str_repeat(' ', $param['typeSpace']);
                         $content .= $param['var'];
                         $content .= str_repeat(' ', $param['varSpace']);
-                        $content .= $param['commentLines'][0]['comment'];
+                        if (isset($param['commentLines'][0])) {
+                            $content .= $param['commentLines'][0]['comment'];
+                        }
                         $phpcsFile->fixer->replaceToken(($param['tag'] + 2), $content);
                     }
                 }


### PR DESCRIPTION
This fixes a bug I ran in to:
PHP Fatal error: Uncaught exception 'PHP_CodeSniffer\Exceptions\RuntimeException' with message 'Undefined offset: 0 in .../phpcs-cake3/vendor/cakephp/cakephp-codesniffer/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php on line 400' in .../phpcs-cake3/vendor/squizlabs/php_codesniffer/src/Runner.php:606