### PR TITLE
Bump php version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.1
+  - 7.2
   - 7.3
 
 env:
@@ -12,7 +12,7 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 7.1
+    - php: 7.2
       env: PREFER_LOWEST=1
 
     - php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "source": "https://github.com/cakephp/cakephp-codesniffer"
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "slevomat/coding-standard": "^5.0",
         "squizlabs/php_codesniffer": "3.5.*"
     },


### PR DESCRIPTION
when cake core uses php 7.2 phpcs could not require at least version 7.1 ?