### PR TITLE
Update to be compatible with PSR12 and squizlabs/php_codesniffer:3.5.2

### DIFF
--- a/CakePHP/Sniffs/Commenting/DocBlockAlignmentSniff.php
+++ b/CakePHP/Sniffs/Commenting/DocBlockAlignmentSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Parses and verifies the doc comments for functions.
  *
@@ -12,6 +13,7 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  * @link      http://pear.php.net/package/PHP_CodeSniffer
  */
+
 namespace CakePHP\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
@@ -172,7 +174,8 @@ class FunctionCommentSniff extends PearFunctionCommentSniff
                     continue;
                 }
 
-                if ($tokens[$returnToken]['code'] === T_RETURN
+                if (
+                    $tokens[$returnToken]['code'] === T_RETURN
                     || $tokens[$returnToken]['code'] === T_YIELD
                     || $tokens[$returnToken]['code'] === T_YIELD_FROM
                 ) {

--- a/CakePHP/Sniffs/ControlStructures/ControlStructuresSniff.php
+++ b/CakePHP/Sniffs/ControlStructures/ControlStructuresSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
+++ b/CakePHP/Sniffs/ControlStructures/ElseIfDeclarationSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/ControlStructures/WhileStructuresSniff.php
+++ b/CakePHP/Sniffs/ControlStructures/WhileStructuresSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/Formatting/BlankLineBeforeReturnSniff.php
+++ b/CakePHP/Sniffs/Formatting/BlankLineBeforeReturnSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace CakePHP\Sniffs\Formatting;
 
 use PHP_CodeSniffer\Files\File;
@@ -42,7 +43,8 @@ class BlankLineBeforeReturnSniff implements Sniff
         $prevLineTokens = [];
 
         while ($current >= 0 && $tokens[$current]['line'] >= $previousLine) {
-            if ($tokens[$current]['line'] == $previousLine
+            if (
+                $tokens[$current]['line'] == $previousLine
                 && $tokens[$current]['type'] !== 'T_WHITESPACE'
                 && $tokens[$current]['type'] !== 'T_COMMENT'
                 && $tokens[$current]['type'] !== 'T_DOC_COMMENT_OPEN_TAG'
@@ -56,7 +58,8 @@ class BlankLineBeforeReturnSniff implements Sniff
             $current--;
         }
 
-        if (isset($prevLineTokens[0])
+        if (
+            isset($prevLineTokens[0])
             && ($prevLineTokens[0] === 'T_OPEN_CURLY_BRACKET'
                 || $prevLineTokens[0] === 'T_COLON'
                 || $prevLineTokens[0] === 'T_OPEN_TAG')

--- a/CakePHP/Sniffs/Formatting/UseInAlphabeticalOrderSniff.php
+++ b/CakePHP/Sniffs/Formatting/UseInAlphabeticalOrderSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/Functions/ClosureDeclarationSniff.php
+++ b/CakePHP/Sniffs/Functions/ClosureDeclarationSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *
@@ -14,6 +15,7 @@
  * @since         CakePHP CodeSniffer 0.1.28
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakePHP\Sniffs\Functions;
 
 use PHP_CodeSniffer\Files\File;

--- a/CakePHP/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
+++ b/CakePHP/Sniffs/Functions/FunctionDeclarationArgumentSpacingSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *
@@ -14,6 +15,7 @@
  * @since         CakePHP CodeSniffer 0.1.18
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace CakePHP\Sniffs\Functions;
 
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\Functions\FunctionDeclarationArgumentSpacingSniff as SquizFunctionDeclarationArgumentSpacingSniff;

--- a/CakePHP/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/CakePHP/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/NamingConventions/ValidTraitNameSniff.php
+++ b/CakePHP/Sniffs/NamingConventions/ValidTraitNameSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/PHP/DisallowShortOpenTagSniff.php
+++ b/CakePHP/Sniffs/PHP/DisallowShortOpenTagSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/PHP/TypeCastingSniff.php
+++ b/CakePHP/Sniffs/PHP/TypeCastingSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/CakePHP/Sniffs/Strings/ConcatenationSpacingSniff.php
+++ b/CakePHP/Sniffs/Strings/ConcatenationSpacingSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/CakePHP/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/WhiteSpace/EmptyLinesSniff.php
+++ b/CakePHP/Sniffs/WhiteSpace/EmptyLinesSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *
@@ -45,7 +46,8 @@ class EmptyLinesSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
         // If the current and next two tokens are newlines
         // We can remove the next token (the first newline)
-        if ($tokens[$stackPtr]['content'] === $phpcsFile->eolChar
+        if (
+            $tokens[$stackPtr]['content'] === $phpcsFile->eolChar
             && isset($tokens[$stackPtr + 1])
             && $tokens[$stackPtr + 1]['content'] === $phpcsFile->eolChar
             && isset($tokens[$stackPtr + 2])

--- a/CakePHP/Sniffs/WhiteSpace/FunctionCallSpacingSniff.php
+++ b/CakePHP/Sniffs/WhiteSpace/FunctionCallSpacingSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/WhiteSpace/FunctionClosingBraceSpaceSniff.php
+++ b/CakePHP/Sniffs/WhiteSpace/FunctionClosingBraceSpaceSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/WhiteSpace/FunctionOpeningBraceSpaceSniff.php
+++ b/CakePHP/Sniffs/WhiteSpace/FunctionOpeningBraceSpaceSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/CakePHP/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)

--- a/CakePHP/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/CakePHP/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/CakePHP/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *
@@ -58,7 +59,8 @@ class OperatorSpacingSniff implements Sniff
 
         // Skip default values in function declarations.
         // and declare statements
-        if ($tokens[$stackPtr]['code'] === T_EQUAL
+        if (
+            $tokens[$stackPtr]['code'] === T_EQUAL
             || $tokens[$stackPtr]['code'] === T_MINUS
         ) {
             if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
@@ -66,7 +68,8 @@ class OperatorSpacingSniff implements Sniff
                 $bracket = array_pop($parenthesis);
                 if (isset($tokens[$bracket]['parenthesis_owner']) === true) {
                     $function = $tokens[$bracket]['parenthesis_owner'];
-                    if ($tokens[$function]['code'] === T_FUNCTION ||
+                    if (
+                        $tokens[$function]['code'] === T_FUNCTION ||
                         $tokens[$function]['code'] === T_DECLARE
                     ) {
                         return;

--- a/CakePHP/Sniffs/WhiteSpace/TabAndSpaceSniff.php
+++ b/CakePHP/Sniffs/WhiteSpace/TabAndSpaceSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHP Version 5
  *

--- a/CakePHP/Tests/ControlStructures/ControlStructuresUnitTest.inc
+++ b/CakePHP/Tests/ControlStructures/ControlStructuresUnitTest.inc
@@ -12,3 +12,15 @@ if ($i < 10) {
 
 if($abc == true)
         echo 'hello';
+
+// PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine
+$foo = true;
+$bar = true;
+$bat = true;
+if (
+    $foo
+    && $bar
+    && $bat
+) {
+    echo 'Hello';
+}

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -9,6 +9,16 @@
     <rule ref="PSR2"/>
 
     <!--
+    Rules from PS2 and PS12 clash. Prioritize PS12
+    -->
+    <!--
+    This rule conflicts with PSR12.ControlStructures.ControlStructureSpacing.FirstExpressionLine
+    -->
+    <rule ref="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace">
+        <severity>0</severity>
+    </rule>
+
+    <!--
     Property and method names with underscore prefix are allowed in CakePHP.
     Not using underscore prefix is a recommendation of PSR2, not a requirement.
     -->

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
           "phpunit --coverage-clover=clover.xml",
           "@reset-ruleset"
         ],
-        "cs-check": "phpcs --colors -p --extensions=php --standard=CakePHP ./CakePHP",
+        "cs-check": "phpcs --colors -p -s --extensions=php --standard=CakePHP ./CakePHP",
         "cs-fix": "phpcbf --colors --extensions=php --standard=CakePHP ./CakePHP"
     }
 }


### PR DESCRIPTION
As the subject line suggests, this makes codesniffer compatible with `squizlabs/php_codesniffer:3.5.2`.

I also added an exception to a PSR2 rule, as it conflicts with a PSR12 rule.