### PR TITLE
Silence PHP7 only sniffs.

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -67,6 +67,13 @@
         <severity>0</severity>
     </rule>
 
+    <!--
+    These are not applicable for PHP5.6+
+    -->
+    <rule ref="PSR12.Properties.ConstantVisibility">
+        <severity>0</severity>
+    </rule>
+
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
             <property name="ignoreBlankLines" value="false"/>


### PR DESCRIPTION
> Visibility must be declared on all constants if your project supports PHP 7.1 or later

warnings etc are not useful for cake3.x