### PR TITLE
Checked separately for ordering by `use function` and `use const`

### DIFF
--- a/CakePHP/Tests/Formatting/UseInAlphabeticalOrderUnitTest.3.inc
+++ b/CakePHP/Tests/Formatting/UseInAlphabeticalOrderUnitTest.3.inc
@@ -1,0 +1,13 @@
+<?php
+namespace BryanCrowe;
+
+use Exception;
+use RuntimeException;
+
+use function compact;
+
+class Foo
+{
+    use FirstTrait;
+    use LogTrait;
+}


### PR DESCRIPTION
fixes #214

That can enable work with PSR12.Files.FileHeader.IncorrectGrouping