### PR TITLE
Added trailing comma sniff and fixed inheritdoc detect

### DIFF
--- a/CakePHP/Sniffs/Commenting/DocBlockAlignmentSniff.php
+++ b/CakePHP/Sniffs/Commenting/DocBlockAlignmentSniff.php
@@ -50,7 +50,7 @@ class DocBlockAlignmentSniff implements Sniff
             if ($fix === true) {
                 // Collect tokens to change indentation of
                 $tokensToIndent = [
-                    $stackPtr => $codeIndentation
+                    $stackPtr => $codeIndentation,
                 ];
                 $commentOpenLine = $tokens[$stackPtr]['line'];
                 $commentCloseLine = $tokens[$commentClose]['line'];

--- a/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
@@ -62,7 +62,7 @@ class FunctionCommentSniff extends PearFunctionCommentSniff
         $end = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, $start);
         $content = $phpcsFile->getTokensAsString($start, ($end - $start));
 
-        return preg_match('/{@inheritDoc}/i', $content) === 1;
+        return preg_match('/{@inheritDoc}|@inheritDoc/i', $content) === 1;
     }
 
     /**

--- a/CakePHP/Sniffs/PHP/CommaAfterArrayItemSniff.php
+++ b/CakePHP/Sniffs/PHP/CommaAfterArrayItemSniff.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace CakePHP\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Adds trailing commas in multiline arrays.
+ *
+ * Heredoc patch taken from slevomat/coding-standard project.
+ *
+ * @author Mark Scherer
+ * @license MIT
+ */
+class CommaAfterArrayItemSniff implements Sniff
+{
+
+    /**
+     * @var bool
+     */
+    public $enableAfterHeredoc = PHP_VERSION_ID >= 70300;
+
+    /**
+     * @inheritDoc
+     */
+    public function register()
+    {
+        return [
+            T_OPEN_SHORT_ARRAY,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $arrayToken = $tokens[$stackPtr];
+        $closeParenthesisPointer = $arrayToken['bracket_closer'];
+        $openParenthesisToken = $tokens[$arrayToken['bracket_opener']];
+        $closeParenthesisToken = $tokens[$closeParenthesisPointer];
+        if ($openParenthesisToken['line'] === $closeParenthesisToken['line']) {
+            return;
+        }
+
+        $previousToCloseParenthesisPointer = $phpcsFile->findPrevious(Tokens::$emptyTokens, $closeParenthesisPointer - 1, 0, true);
+        $previousToCloseParenthesisToken = $tokens[$previousToCloseParenthesisPointer];
+        if (
+            $previousToCloseParenthesisPointer === $arrayToken['bracket_opener']
+            || $previousToCloseParenthesisToken['code'] === T_COMMA
+            || $closeParenthesisToken['line'] === $previousToCloseParenthesisToken['line']
+        ) {
+            return;
+        }
+        if (!$this->enableAfterHeredoc && in_array($previousToCloseParenthesisToken['code'], [T_END_HEREDOC, T_END_NOWDOC], true)) {
+            return;
+        }
+        $fix = $phpcsFile->addFixableError(
+            'Multi-line arrays must have a trailing comma after the last element.',
+            $previousToCloseParenthesisPointer,
+            'MissingTrailingComma'
+        );
+        if (!$fix) {
+            return;
+        }
+
+        $phpcsFile->fixer->beginChangeset();
+        $phpcsFile->fixer->addContent($previousToCloseParenthesisPointer, ',');
+        $phpcsFile->fixer->endChangeset();
+    }
+}

--- a/CakePHP/Sniffs/PHP/CommaAfterArrayItemSniff.php
+++ b/CakePHP/Sniffs/PHP/CommaAfterArrayItemSniff.php
@@ -16,7 +16,6 @@ use PHP_CodeSniffer\Util\Tokens;
  */
 class CommaAfterArrayItemSniff implements Sniff
 {
-
     /**
      * @var bool
      */

--- a/CakePHP/Tests/Commenting/DocBlockAlignmentUnitTest.php
+++ b/CakePHP/Tests/Commenting/DocBlockAlignmentUnitTest.php
@@ -18,7 +18,7 @@ class DocBlockAlignmentUnitTest extends AbstractSniffUnitTest
                     7 => 1,
                     14 => 1,
                     21 => 1,
-                    30 => 1
+                    30 => 1,
                 ];
 
             default:


### PR DESCRIPTION
Backports the PHP7 and Cake4 trailing comma to PHP5 and Cake3 to keep the files in sync (less diff issues).

Also `@inheritDoc` should be properly detected as full overwrite.