### PR TITLE
Upgrade to use slevomat/coding-standard v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^7.1",
-        "slevomat/coding-standard": "^5.0",
+        "slevomat/coding-standard": "^6.0",
         "squizlabs/php_codesniffer": "~3.5.0"
     },
     "require-dev": {


### PR DESCRIPTION
This is mainly to include the fix for https://github.com/slevomat/coding-standard/issues/772 (Which directly affects our template files)