### PR TITLE
Add sniff to test whether @inheritDoc is the only comment in doc block.

### DIFF
--- a/CakePHP/Sniffs/Commenting/InheritDocSniff.php
+++ b/CakePHP/Sniffs/Commenting/InheritDocSniff.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://github.com/cakephp/cakephp-codesniffer
+ * @since         CakePHP CodeSniffer 4.1.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace CakePHP\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Validates proper @inheritDoc use.
+ */
+class InheritDocSniff implements Sniff
+{
+    /**
+     * @inheritDoc
+     */
+    public function register()
+    {
+        return [T_DOC_COMMENT_OPEN_TAG];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $commentStart = $stackPtr;
+        $commentEnd = $tokens[$stackPtr]['comment_closer'];
+
+        $empty = [
+            T_DOC_COMMENT_WHITESPACE,
+            T_DOC_COMMENT_STAR,
+        ];
+
+        $comment = $phpcsFile->findNext($empty, $stackPtr + 1, $commentEnd, true);
+        if ($comment === false) {
+            // Ignore empty comments
+            return;
+        }
+
+        if (
+            preg_match('/^@inheritDoc$/i', $tokens[$comment]['content']) === 1 &&
+            $phpcsFile->findNext($empty, $comment + 1, $commentEnd, true) !== false
+        ) {
+            $msg = '@inheritDoc doc comments must not contain anything else';
+            $phpcsFile->addError($msg, $comment, 'InvalidInheritDoc');
+        }
+    }
+}

--- a/CakePHP/Tests/Commenting/InheritDocUnitTest.1.inc
+++ b/CakePHP/Tests/Commenting/InheritDocUnitTest.1.inc
@@ -1,0 +1,19 @@
+<?php
+namespace App\Person\Patient;
+
+class Foo extends Bar
+{
+    /**
+     * @inheritDoc
+     */
+    public $brain = [];
+
+    /**
+     * @inheritDoc
+     *
+     * @return void
+     */
+    public function dumpThoughts($thoughts)
+    {
+    }
+}

--- a/CakePHP/Tests/Commenting/InheritDocUnitTest.php
+++ b/CakePHP/Tests/Commenting/InheritDocUnitTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace CakePHP\Tests\Commenting;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class InheritDocUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getErrorList($testFile = '')
+    {
+        switch ($testFile) {
+            case 'InheritDocUnitTest.1.inc':
+                return [
+                    '12' => 1,
+                ];
+
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
This sniff only tests the `@inheritDoc` comment not `{@inheritDoc}`. This sniff adds 0 failures to current cakephp master branch.