### PR TITLE
Fix min constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.2",
         "slevomat/coding-standard": "^6.0",
-        "squizlabs/php_codesniffer": "~3.5.0"
+        "squizlabs/php_codesniffer": "~3.5.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.1"


### PR DESCRIPTION
why are we still setting that dependency manually in the first place? squizlabs/php_codesniffer