### PR TITLE
Added sniffs checking that {@inheritdoc} is formatted correctly.

### DIFF
--- a/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
@@ -58,11 +58,22 @@ class FunctionCommentSniff extends PearFunctionCommentSniff
      */
     protected function isInheritDoc(File $phpcsFile, $stackPtr)
     {
-        $start = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr - 1);
-        $end = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, $start);
-        $content = $phpcsFile->getTokensAsString($start, $end - $start);
+        $tokens = $phpcsFile->getTokens();
 
-        return preg_match('/@inheritDoc\b/i', $content) === 1;
+        $start = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr - 1);
+        $end = $tokens[$start]['comment_closer'];
+
+        $empty = [
+            T_DOC_COMMENT_WHITESPACE,
+            T_DOC_COMMENT_STAR,
+        ];
+
+        $inheritDoc = $phpcsFile->findNext($empty, $start + 1, $end, true);
+        if ($inheritDoc === false) {
+            return false;
+        }
+
+        return preg_match('/^@inheritDoc$/i', $tokens[$inheritDoc]['content']) === 1;
     }
 
     /**

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -236,14 +236,14 @@ class Foo
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function inherited()
     {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function inheritedCaseInsentive()
     {

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -236,14 +236,14 @@ class Foo
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function inherited()
     {
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function inheritedCaseInsentive()
     {

--- a/CakePHP/Tests/Commenting/InheritDocUnitTest.1.inc
+++ b/CakePHP/Tests/Commenting/InheritDocUnitTest.1.inc
@@ -16,9 +16,18 @@ class Foo extends Bar
     /**
      * {@inheritDoc}
      *
+     * Extra description.
+     *
      * @var int[]
      */
     public $body = [];
+
+    /**
+     * {@inheritDoc} Extra description.
+     *
+     * @var int[]
+     */
+    public $hand = [];
 
     /**
      * {@inheritDoc}

--- a/CakePHP/Tests/Commenting/InheritDocUnitTest.1.inc.fixed
+++ b/CakePHP/Tests/Commenting/InheritDocUnitTest.1.inc.fixed
@@ -16,9 +16,18 @@ class Foo extends Bar
     /**
      * {@inheritDoc}
      *
+     * Extra description.
+     *
      * @var int[]
      */
     public $body = [];
+
+    /**
+     * {@inheritDoc} Extra description.
+     *
+     * @var int[]
+     */
+    public $hand = [];
 
     /**
      * @inheritDoc

--- a/CakePHP/Tests/Commenting/InheritDocUnitTest.php
+++ b/CakePHP/Tests/Commenting/InheritDocUnitTest.php
@@ -14,8 +14,9 @@ class InheritDocUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
             case 'InheritDocUnitTest.1.inc':
                 return [
-                    '24' => 1,
-                    '29' => 1,
+                    '26' => 1,
+                    '33' => 1,
+                    '38' => 1,
                 ];
 
             default:


### PR DESCRIPTION
This enables function comment sniffs when the comment starts with `{@inheritDoc}` only instead of checking entire block for it.