### PR TITLE
Clamp down Slevomat CS to <6.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^7.2",
-        "slevomat/coding-standard": "^6.0",
+        "slevomat/coding-standard": ">=6.0 <6.2",
         "squizlabs/php_codesniffer": "~3.5.3"
     },
     "require-dev": {


### PR DESCRIPTION
Change can be reverted after slevomat/coding-standard#954 is addressed.