### PR TITLE
Changed inheritDoc errors to warnings and updated messages

### DIFF
--- a/CakePHP/Tests/Commenting/InheritDocUnitTest.1.inc
+++ b/CakePHP/Tests/Commenting/InheritDocUnitTest.1.inc
@@ -30,6 +30,15 @@ class Foo extends Bar
     public $hand = [];
 
     /**
+     * Short description first.
+     *
+     * {@inheritDoc}
+     *
+     * @var int[]
+     */
+    public $finger = [];
+
+    /**
      * {@inheritDoc}
      */
     public $toe = [];

--- a/CakePHP/Tests/Commenting/InheritDocUnitTest.1.inc.fixed
+++ b/CakePHP/Tests/Commenting/InheritDocUnitTest.1.inc.fixed
@@ -30,6 +30,15 @@ class Foo extends Bar
     public $hand = [];
 
     /**
+     * Short description first.
+     *
+     * {@inheritDoc}
+     *
+     * @var int[]
+     */
+    public $finger = [];
+
+    /**
      * @inheritDoc
      */
     public $toe = [];

--- a/CakePHP/Tests/Commenting/InheritDocUnitTest.php
+++ b/CakePHP/Tests/Commenting/InheritDocUnitTest.php
@@ -14,9 +14,6 @@ class InheritDocUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
             case 'InheritDocUnitTest.1.inc':
                 return [
-                    '26' => 1,
-                    '33' => 1,
-                    '38' => 1,
                 ];
 
             default:
@@ -33,6 +30,10 @@ class InheritDocUnitTest extends AbstractSniffUnitTest
             case 'InheritDocUnitTest.1.inc':
                 return [
                     '12' => 1,
+                    '26' => 1,
+                    '35' => 1,
+                    '42' => 1,
+                    '47' => 1,
                 ];
 
             default:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,11 @@
         }
     },
     "scripts": {
-        "test": "phpunit --filter CakePHP",
+        "add-standard" : "phpcs --config-set installed_paths $(pwd)",
+        "test": [
+          "@add-standard",
+          "phpunit --filter CakePHP"
+        ],
         "cs-check": "phpcs --colors --parallel=16 -p -s CakePHP/",
         "cs-fix": "phpcbf --colors --parallel=16 -p CakePHP/",
         "lowest": " validate-prefer-lowest",


### PR DESCRIPTION
I accidentally broke setting the installed_paths for unit tests earlier.

Other doc comment sniffs throw warnings instead of errors so inheritDoc should do the same.