### PR TITLE
Allow {@inheritDoc} doc comments to include certain tags

### DIFF
--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -258,4 +258,33 @@ class Foo
     public function intersectionType($param)
     {
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function withInheritDocNoTags($param)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \Exception Comment.
+     * @see \Exception
+     * @link http://cakephp.org
+     * @psalm-suppress SomeError
+     * @phpstan-tag SomeError
+     */
+    public function withInheritDocAllowedTags($param)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param int $param This is not allowed on its own.
+     */
+    public function withInheritDocIncompleteTags($param)
+    {
+    }
 }

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -258,4 +258,33 @@ class Foo
     public function intersectionType($param)
     {
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function withInheritDocNoTags($param)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \Exception Comment.
+     * @see \Exception
+     * @link http://cakephp.org
+     * @psalm-suppress SomeError
+     * @phpstan-tag SomeError
+     */
+    public function withInheritDocAllowedTags($param)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param int $param This is not allowed on its own.
+     */
+    public function withInheritDocIncompleteTags($param)
+    {
+    }
 }

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.php
@@ -49,6 +49,7 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
             206 => 1,
             215 => 1,
             221 => 1,
+            286 => 1,
         ];
     }
 }


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp-codesniffer/issues/294

This makes it easier to override a function just to add some error handling or special static analyzer tags. These tags don't require validating the entire function/etc.