### PR TITLE
Update slevomat/coding-standard

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -128,7 +128,7 @@
         <exclude-pattern>*/src/Shell/*</exclude-pattern>
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
-    
+
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility">
         <properties>
@@ -154,7 +154,11 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
-    <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration">
+        <properties>
+            <property name="allowDocCommentAboveReturn" type="boolean" value="true" />
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.NoAssignment">
         <severity>0</severity>
     </rule>

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     },
     "require": {
         "php": "^7.2",
-        "slevomat/coding-standard": ">=6.0 <6.2",
-        "squizlabs/php_codesniffer": "~3.5.3"
+        "slevomat/coding-standard": "^6.2",
+        "squizlabs/php_codesniffer": "~3.5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.1"


### PR DESCRIPTION
This allows using inline "@var" annotations above return statements
without variable name which are supported by psalm and phpstan.