### PR TITLE
Bump up Slevomat CS version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     },
     "require": {
         "php": "^7.2",
-        "slevomat/coding-standard": "^6.2",
-        "squizlabs/php_codesniffer": "~3.5.4"
+        "slevomat/coding-standard": "^6.3.6",
+        "squizlabs/php_codesniffer": "~3.5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.1"


### PR DESCRIPTION
v6.3.6 contains a fix we need to avoid false positives for CakePHP codebase.