### PR TITLE
Removed InvalidReturn sniff as it doesn't handle compound types

### DIFF
--- a/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
@@ -153,39 +153,13 @@ class FunctionCommentSniff extends PearFunctionCommentSniff
             return;
         }
 
-        // Check return type (can be multiple, separated by '|').
-        [$types, ] = explode(' ', $content);
-        $typeNames = explode('|', $types);
-        $suggestedNames = [];
-        foreach ($typeNames as $i => $typeName) {
-            if ($typeName === 'integer') {
-                $suggestedName = 'int';
-            } elseif ($typeName === 'boolean') {
-                $suggestedName = 'bool';
-            } elseif (in_array($typeName, ['int', 'bool'])) {
-                $suggestedName = $typeName;
-            } else {
-                $suggestedName = Common::suggestType($typeName);
-            }
-            if (in_array($suggestedName, $suggestedNames) === false) {
-                $suggestedNames[] = $suggestedName;
-            }
-        }
-
-        $suggestedType = implode('|', $suggestedNames);
-        if ($types !== $suggestedType) {
-            $error = 'Expected "%s" but found "%s" for function return type';
-            $data = [
-                $suggestedType,
-                $types,
-            ];
-            $phpcsFile->addError($error, $return, 'InvalidReturn', $data);
-        }
-
         $endToken = $tokens[$stackPtr]['scope_closer'] ?? false;
         if (!$endToken) {
             return;
         }
+
+        [$types, ] = explode(' ', $content);
+        $typeNames = explode('|', $types);
 
         // If the return type is void, make sure there is
         // no non-void return statements in the function.

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -101,22 +101,6 @@ class Foo
     }
 
     /**
-     * @return integer
-     */
-    public function returnIntegerFail()
-    {
-        return 1;
-    }
-
-    /**
-     * @return boolean
-     */
-    public function returnBooleanFail()
-    {
-        return false;
-    }
-
-    /**
      * @return int
      */
     public function returnIntPass()

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -101,22 +101,6 @@ class Foo
     }
 
     /**
-     * @return integer
-     */
-    public function returnIntegerFail()
-    {
-        return 1;
-    }
-
-    /**
-     * @return boolean
-     */
-    public function returnBooleanFail()
-    {
-        return false;
-    }
-
-    /**
      * @return int
      */
     public function returnIntPass()

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.php
@@ -20,10 +20,8 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
             35 => 1,
             90 => 1,
             97 => 1,
-            104 => 1,
-            112 => 1,
-            178 => 1,
-            187 => 1,
+            162 => 1,
+            171 => 1,
         ];
     }
 
@@ -36,15 +34,15 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
             14 => 1,
             31 => 2,
             45 => 1,
-            140 => 1,
+            124 => 1,
+            129 => 1,
+            137 => 1,
+            138 => 1,
             145 => 1,
-            153 => 1,
-            154 => 1,
+            146 => 1,
+            155 => 1,
             161 => 1,
-            162 => 1,
-            171 => 1,
-            177 => 1,
-            242 => 1,
+            226 => 1,
         ];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp-codesniffer/issues/311

The important cases are already handled by SlevomatCodingStandard.TypeHints.LongTypeHints.UsedLongTypeHint