### PR TITLE
Allow using the sniffer on PHP 8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "source": "https://github.com/cakephp/cakephp-codesniffer"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2.0",
         "slevomat/coding-standard": "^6.3.6",
         "squizlabs/php_codesniffer": "~3.5.5"
     },


### PR DESCRIPTION
Can't run the test suite on PHP 8 as PHPCS's test suite hasn't been updated to support PHP8 / phpunit 9.