### PR TITLE
Remove PSR2

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -18,19 +18,6 @@
     </rule>
 
     <!--
-    These are contradictory to PSR12
-    -->
-    <rule ref="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingAfterSecond">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingAfterFirst">
-        <severity>0</severity>
-    </rule>
-
-    <!--
     Property and method names with underscore prefix are allowed in CakePHP.
     Not using underscore prefix is a recommendation of PSR2, not a requirement.
     -->

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -8,7 +8,6 @@
     <exclude-pattern>/*/tmp/</exclude-pattern>
     <exclude-pattern>tests/*/templates/*</exclude-pattern>
 
-    <rule ref="PSR2"/>
     <rule ref="PSR12"/>
 
     <rule ref="PSR12.Files.FileHeader.SpacingAfterBlock">
@@ -135,7 +134,7 @@
     <rule ref="Squiz.Classes.ClassFileName.NoMatch">
         <exclude-pattern>*/config/Migrations/*</exclude-pattern>
     </rule>
-    
+
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility">
         <properties>


### PR DESCRIPTION
Since PSR12 extends and "replaces" PSR2, we shouldn't need to include it here. PSR12 standard includes the relevant PSR2 sniffs.

Removed anti-PSR12 rule suppressions since PSR12 already suppresses these rules:

https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Standards/PSR12/ruleset.xml#L232
