### PR TITLE
Disable requiring $object::class

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -136,7 +136,7 @@
     </rule>
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference">
         <properties>
-            <property name"enableOnObjects" value="false"/>
+            <property name="enableOnObjects" value="false"/>
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment"/>

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -134,7 +134,11 @@
             <property name="linesCountBeforeClosingBrace" value="0"/>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
+    <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference">
+        <properties>
+            <property name"enableOnObjects" value="false"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
         <properties>


### PR DESCRIPTION
This option defaults to true when using php 8+ which causes inconsistent results. Disabling by default to get the same results with 7.4 and 8.0.