### PR TITLE
Fix ReturnTypeHintSniff error codes missing CakePHP namespace

### DIFF
--- a/CakePHP/Sniffs/Classes/ReturnTypeHintSniff.php
+++ b/CakePHP/Sniffs/Classes/ReturnTypeHintSniff.php
@@ -67,7 +67,7 @@ class ReturnTypeHintSniff implements Sniff
             $phpcsFile->addError(
                 'Chaining methods (@return $this) should not have any return-type-hint.',
                 $startIndex,
-                'TypeHint.Invalid.Self'
+                'InvalidSelf'
             );
 
             return;
@@ -76,7 +76,7 @@ class ReturnTypeHintSniff implements Sniff
         $fix = $phpcsFile->addFixableError(
             'Chaining methods (@return $this) should not have any return-type-hint (Remove "self").',
             $startIndex,
-            'TypeHint.Invalid.Self'
+            'InvalidSelf'
         );
         if (!$fix) {
             return;
@@ -175,7 +175,7 @@ class ReturnTypeHintSniff implements Sniff
             $phpCsFile->addError(
                 'Class name repeated, expected `self` or `$this`.',
                 $classNameIndex,
-                'TypeHint.Invalid.Class'
+                'InvalidClass'
             );
         }
     }


### PR DESCRIPTION
The `ReturnTypeHintSniff` was not properly reporting its sniff codes on errors, making it (for me) to track down where this was even coming from. This is because the `addError` function from PHPCS expects either you pass it a string that represents the error code from this sniff file (which it constructs) or the fully quantified code when using `.`. This file was using the latter, but not actually providing the full quantification, which was then missing up `phpcs -e` as well as printing out a somewhat confusing error code for tracking down where itw was coming from. This fixes it so that now they're properly quantified, and match what was printed within the README for sniffs coming from this file (`CakePHP.Classes.ReturnTypeHint`).

Looking at the code, I was not sure if there was a meaningful reason to have it namespaced out past the usual four elements (e.g. `CakePHP.Classes.ReturnTypeHint.Invalid.Self`) and so just went with convention here.

Before:

```
  8 | ERROR | Class name repeated, expected `self` or `$this`.
    |       | (TypeHint.Invalid.Class)
 10 | ERROR | Chaining methods (@return $this) should not have any return-type-hint.
    |       | (TypeHint.Invalid.Self)
```

After:

```
  8 | ERROR | Class name repeated, expected `self` or `$this`.
    |       | (CakePHP.Classes.ReturnTypeHint.InvalidClass)
 10 | ERROR | Chaining methods (@return $this) should not have any return-type-hint.
    |       | (CakePHP.Classes.ReturnTypeHint.InvalidSelf)
```