### PR TITLE
cake 5: Switch to slevomat parameter typehint sniffs

### DIFF
--- a/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
@@ -16,7 +16,6 @@ namespace CakePHP\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PHP_CodeSniffer\Util\Common;
 use PHP_CodeSniffer\Util\Tokens;
 
 /**
@@ -178,7 +177,6 @@ class FunctionCommentSniff implements Sniff
 
         $this->processReturn($phpcsFile, $stackPtr, $commentStart);
         $this->processThrows($phpcsFile, $stackPtr, $commentStart);
-        $this->processParams($phpcsFile, $stackPtr, $commentStart);
     }
 
     /**
@@ -385,192 +383,6 @@ class FunctionCommentSniff implements Sniff
                 $error = 'Exception type and comment missing for @throws tag in function comment';
                 $phpcsFile->addWarning($error, $tag, 'InvalidThrows');
             }
-        }
-    }
-
-    /**
-     * Process the function parameter comments.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int $stackPtr The position of the current token in the stack passed in $tokens.
-     * @param int $commentStart The position in the stack where the comment started.
-     * @return void
-     */
-    protected function processParams(File $phpcsFile, $stackPtr, $commentStart)
-    {
-        if ($this->isInheritDoc($phpcsFile, $commentStart)) {
-            return;
-        }
-
-        $tokens = $phpcsFile->getTokens();
-
-        $params = [];
-        $maxType = $maxVar = 0;
-        foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
-            if ($tokens[$tag]['content'] !== '@param') {
-                continue;
-            }
-
-            $type = $var = $comment = '';
-            $typeSpace = $varSpace = 0;
-            $commentLines = [];
-            if ($tokens[$tag + 2]['code'] === T_DOC_COMMENT_STRING) {
-                $matches = [];
-                preg_match('/([^$]+)(?:((?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[$tag + 2]['content'], $matches);
-
-                $typeLen = strlen($matches[1]);
-                $type = trim($matches[1]);
-                $typeSpace = $typeLen - strlen($type);
-                $typeLen = strlen($type);
-                if ($typeLen > $maxType) {
-                    $maxType = $typeLen;
-                }
-
-                if (isset($matches[2]) === true) {
-                    $var = $matches[2];
-                    $varLen = strlen($var);
-                    if ($varLen > $maxVar) {
-                        $maxVar = $varLen;
-                    }
-
-                    if (isset($matches[4]) === true) {
-                        $varSpace = strlen($matches[3]);
-                        $comment = $matches[4];
-                        $commentLines[] = [
-                            'comment' => $comment,
-                            'token' => $tag + 2,
-                            'indent' => $varSpace,
-                        ];
-
-                        // Any strings until the next tag belong to this comment.
-                        if (isset($tokens[$commentStart]['comment_tags'][$pos + 1]) === true) {
-                            $end = $tokens[$commentStart]['comment_tags'][$pos + 1];
-                        } else {
-                            $end = $tokens[$commentStart]['comment_closer'];
-                        }
-
-                        for ($i = $tag + 3; $i < $end; $i++) {
-                            if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
-                                $indent = 0;
-                                if ($tokens[$i - 1]['code'] === T_DOC_COMMENT_WHITESPACE) {
-                                    $indent = strlen($tokens[$i - 1]['content']);
-                                }
-
-                                $comment .= ' ' . $tokens[$i]['content'];
-                                $commentLines[] = [
-                                    'comment' => $tokens[$i]['content'],
-                                    'token' => $i,
-                                    'indent' => $indent,
-                                ];
-                            }
-                        }
-                    } else {
-                        $error = 'Missing parameter comment';
-                        $phpcsFile->addError($error, $tag, 'MissingParamComment');
-                        $commentLines[] = ['comment' => ''];
-                    }
-                } else {
-                    $error = 'Missing parameter name';
-                    $phpcsFile->addError($error, $tag, 'MissingParamName');
-                }
-            } else {
-                $error = 'Missing parameter type';
-                $phpcsFile->addError($error, $tag, 'MissingParamType');
-            }
-
-            $params[] = compact('tag', 'type', 'var', 'comment', 'commentLines', 'typeSpace', 'varSpace');
-        }
-
-        $realParams = $phpcsFile->getMethodParameters($stackPtr);
-        $foundParams = [];
-
-        foreach ($params as $pos => $param) {
-            // If the type is empty, the whole line is empty.
-            if ($param['type'] === '') {
-                continue;
-            }
-
-            // Check the param type value.
-            $typeNames = explode('|', $param['type']);
-            foreach ($typeNames as $typeName) {
-                if ($typeName === 'integer') {
-                    $suggestedName = 'int';
-                } elseif ($typeName === 'boolean') {
-                    $suggestedName = 'bool';
-                } elseif (in_array($typeName, ['int', 'bool'])) {
-                    $suggestedName = $typeName;
-                } else {
-                    $suggestedName = Common::suggestType($typeName);
-                }
-
-                if ($typeName !== $suggestedName) {
-                    $error = 'Expected "%s" but found "%s" for parameter type';
-                    $data = [$suggestedName, $typeName];
-
-                    $fix = $phpcsFile->addFixableError($error, $param['tag'], 'IncorrectParamVarName', $data);
-                    if ($fix === true) {
-                        $content = $suggestedName;
-                        $content .= str_repeat(' ', $param['typeSpace']);
-                        $content .= $param['var'];
-                        $content .= str_repeat(' ', $param['varSpace']);
-                        if (isset($param['commentLines'][0])) {
-                            $content .= $param['commentLines'][0]['comment'];
-                        }
-                        $phpcsFile->fixer->replaceToken($param['tag'] + 2, $content);
-                    }
-                }
-            }
-
-            if ($param['var'] === '') {
-                continue;
-            }
-
-            $foundParams[] = $param['var'];
-
-            // Make sure the param name is correct.
-            if (isset($realParams[$pos]) === true) {
-                $realName = $realParams[$pos]['name'];
-                if ($realName !== $param['var']) {
-                    $code = 'ParamNameNoMatch';
-                    $data = [$param['var'], $realName];
-
-                    $error = 'Doc comment for parameter %s does not match ';
-                    if (strtolower($param['var']) === strtolower($realName)) {
-                        $error .= 'case of ';
-                        $code = 'ParamNameNoCaseMatch';
-                    }
-
-                    $error .= 'actual variable name %s';
-
-                    $fix = $phpcsFile->addFixableWarning($error, $param['tag'], $code, $data);
-
-                    if ($fix === true) {
-                        $content = $suggestedName;
-                        $content .= str_repeat(' ', $param['typeSpace']);
-                        $content .= $realName;
-                        $content .= str_repeat(' ', $param['varSpace']);
-                        $content .= $param['commentLines'][0]['comment'];
-                        $phpcsFile->fixer->replaceToken($param['tag'] + 2, $content);
-                    }
-                }
-            } elseif (substr($param['var'], -4) !== ',...') {
-                // We must have an extra parameter comment.
-                $error = 'Superfluous parameter comment';
-                $phpcsFile->addError($error, $param['tag'], 'ExtraParamComment');
-            }
-        }
-
-        $realNames = [];
-        foreach ($realParams as $realParam) {
-            $realNames[] = $realParam['name'];
-        }
-
-        // Report missing comments.
-        $diff = array_diff($realNames, $foundParams);
-        foreach ($diff as $neededParam) {
-            $error = 'Doc comment for parameter "%s" missing';
-            $data = [$neededParam];
-            $phpcsFile->addWarning($error, $commentStart, 'MissingParamTag', $data);
         }
     }
 }

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -9,39 +9,6 @@ class Foo
     /**
      * Some sentence.
      *
-     * @param integer $param Some Param.
-     * @param boolean $otherParam Some Other Param.
-     * @return string Something.
-     */
-    public function bar($param, $otherParam)
-    {
-    }
-
-    /**
-    * Some sentence.
-    *
-    * @param int $param
-    * @param bool $otherParam
-    * @return void
-    */
-    public function missingParamComment($param, $otherParam)
-    {
-    }
-
-    /**
-     * Some sentence.
-     *
-     * @param
-     * @param
-     * @return void
-     */
-    public function missingParamType($param, $otherParam)
-    {
-    }
-
-    /**
-     * Some sentence.
-     *
      * @return void
      */
     public function invalidReturnVoid()
@@ -135,44 +102,11 @@ class Foo
     }
 
     /**
-     * @param int $para Comment.
-     * @return void
-     */
-    public function paramNameNoMatch($param)
-    {
-    }
-
-    /**
-     * @param int $Param Comment.
-     * @return void
-     */
-    public function paramNameNoCaseMatch($param)
-    {
-    }
-
-    /**
      *
      */
     public function missingReturn()
     {
         return 'what';
-    }
-
-    /**
-     * @param int
-     * @return void
-     */
-    public function missingParamName($param)
-    {
-    }
-
-    /**
-     * @param int $param A description.
-     * @param int $superflous A description.
-     * @return void
-     */
-    public function extraParamComment($param)
-    {
     }
 
     /**

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -9,39 +9,6 @@ class Foo
     /**
      * Some sentence.
      *
-     * @param int $param Some Param.
-     * @param bool $otherParam Some Other Param.
-     * @return string Something.
-     */
-    public function bar($param, $otherParam)
-    {
-    }
-
-    /**
-    * Some sentence.
-    *
-    * @param int $param
-    * @param bool $otherParam
-    * @return void
-    */
-    public function missingParamComment($param, $otherParam)
-    {
-    }
-
-    /**
-     * Some sentence.
-     *
-     * @param
-     * @param
-     * @return void
-     */
-    public function missingParamType($param, $otherParam)
-    {
-    }
-
-    /**
-     * Some sentence.
-     *
      * @return void
      */
     public function invalidReturnVoid()

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.php
@@ -12,16 +12,8 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
-            12 => 1,
-            13 => 1,
-            23 => 1,
-            24 => 1,
-            34 => 1,
-            35 => 1,
-            90 => 1,
-            97 => 1,
-            162 => 1,
-            171 => 1,
+            57 => 1,
+            64 => 1,
         ];
     }
 
@@ -31,18 +23,11 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
     public function getWarningList()
     {
         return [
-            14 => 1,
-            31 => 2,
-            45 => 1,
-            124 => 1,
-            129 => 1,
-            137 => 1,
-            138 => 1,
-            145 => 1,
-            146 => 1,
-            155 => 1,
-            161 => 1,
-            226 => 1,
+            12 => 1,
+            91 => 1,
+            96 => 1,
+            106 => 1,
+            160 => 1,
         ];
     }
 }

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -199,6 +199,14 @@
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+        <properties>
+            <property name="enableMixedTypeHint" type="boolean" value="false"/>
+            <property name="enableUnionTypeHint" type="boolean" value="false"/>
+        </properties>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+    </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
 


### PR DESCRIPTION
This was tested against cakephp/cakephp.

The mixed and union specific options are disabled for now until we decide how to update types in cake 5. We don't want cs to fail every type that isn't a native type.