### PR TITLE
cake 5: Extend doc comment and attribute spacing checks

### DIFF
--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -7,6 +7,62 @@ use Other\Error as OtherError;
 class Foo
 {
     /**
+     */
+    public function testValidComment()
+    {
+    }
+
+    public function missingComment()
+    {
+    }
+
+    // not valid
+    public function invalidComment()
+    {
+    }
+
+    /**
+     */
+    #[
+        ReturnTypeWillChange
+    ]
+    public function testValidAttribute()
+    {
+    }
+
+    /**
+     */
+
+    public function spaceAfterComment()
+    {
+    }
+
+    /**
+     */
+
+    #[ReturnTypeWillChange]
+    public function spaceAfterCommentAndBeforeAttribute()
+    {
+    }
+
+    /**
+     */
+    #[ReturnTypeWillChange]
+
+    public function spaceAfterCommentAndAttribute()
+    {
+    }
+
+    /**
+     */
+    #[ReturnTypeWillChange]
+
+    #[ReturnTypeWillChange2]
+    public function spaceBetweenCommentAndAttribute()
+    {
+    }
+
+    /**
      * Test throws
      *
      * @throws Exception An expection happened.

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -7,6 +7,62 @@ use Other\Error as OtherError;
 class Foo
 {
     /**
+     */
+    public function testValidComment()
+    {
+    }
+
+    public function missingComment()
+    {
+    }
+
+    // not valid
+    public function invalidComment()
+    {
+    }
+
+    /**
+     */
+    #[
+        ReturnTypeWillChange
+    ]
+    public function testValidAttribute()
+    {
+    }
+
+    /**
+     */
+
+    public function spaceAfterComment()
+    {
+    }
+
+    /**
+     */
+
+    #[ReturnTypeWillChange]
+    public function spaceAfterCommentAndBeforeAttribute()
+    {
+    }
+
+    /**
+     */
+    #[ReturnTypeWillChange]
+
+    public function spaceAfterCommentAndAttribute()
+    {
+    }
+
+    /**
+     */
+    #[ReturnTypeWillChange]
+
+    #[ReturnTypeWillChange2]
+    public function spaceBetweenCommentAndAttribute()
+    {
+    }
+
+    /**
      * Test throws
      *
      * @throws Exception An expection happened.

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.php
@@ -12,6 +12,12 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
     public function getErrorList()
     {
         return [
+            15 => 1,
+            20 => 1,
+            34 => 1,
+            41 => 1,
+            50 => 1,
+            58 => 1,
         ];
     }
 
@@ -21,7 +27,7 @@ class FunctionCommentUnitTest extends AbstractSniffUnitTest
     public function getWarningList()
     {
         return [
-            37 => 1,
+            93 => 1,
         ];
     }
 }


### PR DESCRIPTION
@ADmad This supports spacing in several variations between the docblock, attributes and function.

Cleaned up the old function processing code. This should reduce the amount of code we have to support.

The logic for finding the docblock end is based on slevomat.
