### PR TITLE
Convert use of token type to code

### DIFF
--- a/CakePHP/Sniffs/Classes/ReturnTypeHintSniff.php
+++ b/CakePHP/Sniffs/Classes/ReturnTypeHintSniff.php
@@ -61,8 +61,8 @@ class ReturnTypeHintSniff implements Sniff
             return [];
         }
 
-        $returnTokenType = $tokens[$startIndex]['type'];
-        if ($returnTokenType !== 'T_SELF') {
+        $returnTokenCode = $tokens[$startIndex]['code'];
+        if ($returnTokenCode !== T_SELF) {
             // Then we can only warn, but not auto-fix
             $phpcsFile->addError(
                 'Chaining methods (@return $this) should not have any return-type-hint.',
@@ -107,7 +107,7 @@ class ReturnTypeHintSniff implements Sniff
         $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
 
         for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; $i++) {
-            if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
+            if ($tokens[$i]['code'] !== T_DOC_COMMENT_TAG) {
                 continue;
             }
             if ($tokens[$i]['content'] !== '@return') {
@@ -116,7 +116,7 @@ class ReturnTypeHintSniff implements Sniff
 
             $classNameIndex = $i + 2;
 
-            if ($tokens[$classNameIndex]['type'] !== 'T_DOC_COMMENT_STRING') {
+            if ($tokens[$classNameIndex]['code'] !== T_DOC_COMMENT_STRING) {
                 continue;
             }
 
@@ -149,7 +149,7 @@ class ReturnTypeHintSniff implements Sniff
         $docBlockStartIndex = $tokens[$docBlockEndIndex]['comment_opener'];
 
         for ($i = $docBlockStartIndex + 1; $i < $docBlockEndIndex; $i++) {
-            if ($tokens[$i]['type'] !== 'T_DOC_COMMENT_TAG') {
+            if ($tokens[$i]['code'] !== T_DOC_COMMENT_TAG) {
                 continue;
             }
             if ($tokens[$i]['content'] !== '@return') {
@@ -158,7 +158,7 @@ class ReturnTypeHintSniff implements Sniff
 
             $classNameIndex = $i + 2;
 
-            if ($tokens[$classNameIndex]['type'] !== 'T_DOC_COMMENT_STRING') {
+            if ($tokens[$classNameIndex]['code'] !== T_DOC_COMMENT_STRING) {
                 continue;
             }
 
@@ -197,14 +197,14 @@ class ReturnTypeHintSniff implements Sniff
 
         if (
             !empty($tokens[$beginningOfLine - 2])
-            && $tokens[$beginningOfLine - 2]['type'] === 'T_DOC_COMMENT_CLOSE_TAG'
+            && $tokens[$beginningOfLine - 2]['code'] === T_DOC_COMMENT_CLOSE_TAG
         ) {
             return $beginningOfLine - 2;
         }
 
         if (
             !empty($tokens[$beginningOfLine - 3])
-            && $tokens[$beginningOfLine - 3]['type'] === 'T_DOC_COMMENT_CLOSE_TAG'
+            && $tokens[$beginningOfLine - 3]['code'] === T_DOC_COMMENT_CLOSE_TAG
         ) {
             return $beginningOfLine - 3;
         }

--- a/CakePHP/Sniffs/Commenting/DocBlockAlignmentSniff.php
+++ b/CakePHP/Sniffs/Commenting/DocBlockAlignmentSniff.php
@@ -74,7 +74,7 @@ class DocBlockAlignmentSniff implements Sniff
                 $phpcsFile->fixer->beginChangeset();
                 foreach ($tokensToIndent as $searchToken => $indent) {
                     $indentString = str_repeat(' ', $indent);
-                    $isOpenTag = $tokens[$searchToken]['type'] === 'T_DOC_COMMENT_OPEN_TAG';
+                    $isOpenTag = $tokens[$searchToken]['code'] === T_DOC_COMMENT_OPEN_TAG;
                     if ($isOpenTag && $commentIndentation === 0) {
                         $phpcsFile->fixer->addContentBefore($searchToken, $indentString);
                     } else {

--- a/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
@@ -120,10 +120,10 @@ class FunctionCommentSniff implements Sniff
         ) {
             $previous = $commentEnd;
             if (
-                $tokens[$commentEnd]['type'] === 'T_ATTRIBUTE_END'
-                || $tokens[$commentEnd]['type'] === 'T_ATTRIBUTE'
+                $tokens[$commentEnd]['code'] === T_ATTRIBUTE_END
+                || $tokens[$commentEnd]['code'] === T_ATTRIBUTE
             ) {
-                while ($tokens[$previous]['type'] !== 'T_ATTRIBUTE') {
+                while ($tokens[$previous]['code'] !== T_ATTRIBUTE) {
                     $previous--;
                 }
                 $previous--;

--- a/CakePHP/Sniffs/Formatting/BlankLineBeforeReturnSniff.php
+++ b/CakePHP/Sniffs/Formatting/BlankLineBeforeReturnSniff.php
@@ -58,24 +58,24 @@ class BlankLineBeforeReturnSniff implements Sniff
         while ($current >= 0 && $tokens[$current]['line'] >= $previousLine) {
             if (
                 $tokens[$current]['line'] == $previousLine
-                && $tokens[$current]['type'] !== 'T_WHITESPACE'
-                && $tokens[$current]['type'] !== 'T_COMMENT'
-                && $tokens[$current]['type'] !== 'T_DOC_COMMENT_OPEN_TAG'
-                && $tokens[$current]['type'] !== 'T_DOC_COMMENT_TAG'
-                && $tokens[$current]['type'] !== 'T_DOC_COMMENT_STRING'
-                && $tokens[$current]['type'] !== 'T_DOC_COMMENT_CLOSE_TAG'
-                && $tokens[$current]['type'] !== 'T_DOC_COMMENT_WHITESPACE'
+                && $tokens[$current]['code'] !== T_WHITESPACE
+                && $tokens[$current]['code'] !== T_COMMENT
+                && $tokens[$current]['code'] !== T_DOC_COMMENT_OPEN_TAG
+                && $tokens[$current]['code'] !== T_DOC_COMMENT_TAG
+                && $tokens[$current]['code'] !== T_DOC_COMMENT_STRING
+                && $tokens[$current]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+                && $tokens[$current]['code'] !== T_DOC_COMMENT_WHITESPACE
             ) {
-                $prevLineTokens[] = $tokens[$current]['type'];
+                $prevLineTokens[] = $tokens[$current]['code'];
             }
             $current--;
         }
 
         if (
             isset($prevLineTokens[0])
-            && ($prevLineTokens[0] === 'T_OPEN_CURLY_BRACKET'
-                || $prevLineTokens[0] === 'T_COLON'
-                || $prevLineTokens[0] === 'T_OPEN_TAG')
+            && ($prevLineTokens[0] === T_OPEN_CURLY_BRACKET
+                || $prevLineTokens[0] === T_COLON
+                || $prevLineTokens[0] === T_OPEN_TAG)
         ) {
             return;
         } elseif (count($prevLineTokens) > 0) {

--- a/CakePHP/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/CakePHP/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -57,7 +57,7 @@ class FunctionSpacingSniff implements Sniff
             $nextContentIndex = $phpCsFile->findNext(T_WHITESPACE, $semicolonIndex + 1, null, true);
 
             // Do not mess with the end of the class
-            if ($tokens[$nextContentIndex]['type'] === 'T_CLOSE_CURLY_BRACKET') {
+            if ($tokens[$nextContentIndex]['code'] === T_CLOSE_CURLY_BRACKET) {
                 return;
             }
 
@@ -86,7 +86,7 @@ class FunctionSpacingSniff implements Sniff
         $nextContentIndex = $phpCsFile->findNext(T_WHITESPACE, $closingBraceIndex + 1, null, true);
 
         // Do not mess with the end of the class
-        if ($tokens[$nextContentIndex]['type'] === 'T_CLOSE_CURLY_BRACKET') {
+        if ($tokens[$nextContentIndex]['code'] === T_CLOSE_CURLY_BRACKET) {
             return;
         }
 
@@ -135,11 +135,11 @@ class FunctionSpacingSniff implements Sniff
 
         $prevContentIndex = $phpCsFile->findPrevious(T_WHITESPACE, $firstTokenInLineIndex - 1, null, true);
 
-        if ($tokens[$prevContentIndex]['type'] === 'T_ATTRIBUTE_END') {
+        if ($tokens[$prevContentIndex]['code'] === T_ATTRIBUTE_END) {
             return;
         }
 
-        if ($tokens[$prevContentIndex]['type'] === 'T_DOC_COMMENT_CLOSE_TAG') {
+        if ($tokens[$prevContentIndex]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
             $firstTokenInLineIndex = $tokens[$prevContentIndex]['comment_opener'];
             while ($tokens[$firstTokenInLineIndex - 1]['line'] === $line) {
                 $firstTokenInLineIndex--;
@@ -149,7 +149,7 @@ class FunctionSpacingSniff implements Sniff
         $prevContentIndex = $phpCsFile->findPrevious(T_WHITESPACE, $firstTokenInLineIndex - 1, null, true);
 
         // Do not mess with the start of the class
-        if ($tokens[$prevContentIndex]['type'] === 'T_OPEN_CURLY_BRACKET') {
+        if ($tokens[$prevContentIndex]['code'] === T_OPEN_CURLY_BRACKET) {
             return;
         }
 

--- a/CakePHP/Tests/Classes/ReturnTypeHintUnitTest.inc
+++ b/CakePHP/Tests/Classes/ReturnTypeHintUnitTest.inc
@@ -1,0 +1,26 @@
+<?php
+namespace Beakman;
+
+class Foo
+{
+    /**
+     * @return $this
+     */
+    public function correct()
+    {
+    }
+
+    /**
+     * @return $this
+     */
+    public function incorrect(): Foo
+    {
+    }
+
+    /**
+     * @return $this
+     */
+    public function incorrectSelf(): self
+    {
+    }
+}

--- a/CakePHP/Tests/Classes/ReturnTypeHintUnitTest.php
+++ b/CakePHP/Tests/Classes/ReturnTypeHintUnitTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace CakePHP\Tests\Classes;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class ReturnTypeHintUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * @inheritDoc
+     */
+    public function getErrorList()
+    {
+        return [
+            16 => 1,
+            23 => 1,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getWarningList()
+    {
+        return [
+        ];
+    }
+}

--- a/CakePHP/Tests/Classes/ReturnTypeHintUnitTestinc.fixed
+++ b/CakePHP/Tests/Classes/ReturnTypeHintUnitTestinc.fixed
@@ -1,0 +1,29 @@
+<?php
+namespace Beakman;
+
+use Other\Crap;
+use Other\Error as OtherError;
+
+class Foo
+{
+    /**
+     * @return $this
+     */
+    public function correct()
+    {
+    }
+
+    /**
+     * @return $this
+     */
+    public function incorrect(): Foo
+    {
+    }
+
+    /**
+     * @return $this
+     */
+    public function incorrectSelf()
+    {
+    }
+}


### PR DESCRIPTION
This avoid string comparisons and ensures we use correct values.