### PR TITLE
Convert array type to generic in non-unions

### DIFF
--- a/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc
+++ b/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc
@@ -3,10 +3,10 @@ namespace Beakman;
 
 class Foo
 {
-    /** @var int|string[]|int[] */
+    /** @var string[] */
     protected $testVar;
 
-    /** @var null|string|class-string<\Cake\I18n\Number>|array $testVar2 */
+    /** @var null|string[]|class-string<\Cake\I18n\Number> $testVar2 */
     protected $testVar2;
 
     /**

--- a/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc.fixed
+++ b/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc.fixed
@@ -3,10 +3,10 @@ namespace Beakman;
 
 class Foo
 {
-    /** @var array<string>|array<int>|int */
+    /** @var array<string> */
     protected $testVar;
 
-    /** @var array|class-string<\Cake\I18n\Number>|string|null $testVar2 */
+    /** @var array<string>|class-string<\Cake\I18n\Number>|null $testVar2 */
     protected $testVar2;
 
     /**


### PR DESCRIPTION
This handles single types as well now.

@ADmad 