### PR TITLE
cake 5: Add slevomat property type hint sniffs

### DIFF
--- a/CakePHP/Sniffs/Commenting/TypeHintSniff.php
+++ b/CakePHP/Sniffs/Commenting/TypeHintSniff.php
@@ -43,6 +43,9 @@ class TypeHintSniff implements Sniff
      */
     public $convertArraysToGenerics = true;
 
+    /**
+     * @var array<string>
+     */
     protected static $typeHintTags = [
         '@var',
         '@psalm-var',

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -173,6 +173,7 @@
         </properties>
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
@@ -184,7 +185,19 @@
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"/>
+        <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+        <properties>
+            <property name="enableMixedTypeHint" type="boolean" value="false"/>
+            <property name="enableStaticTypeHint" type="boolean" value="false"/>
+            <property name="enableUnionTypeHint" type="boolean" value="false"/>
+        </properties>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
 


### PR DESCRIPTION
@ADmad This adds the property hint sniffs but disables missing native types like the parameter and return sniffs.

There are no errors in 4.next with this.