### PR TITLE
Use errors instead of warnings

### DIFF
--- a/CakePHP/Sniffs/Commenting/TypeHintSniff.php
+++ b/CakePHP/Sniffs/Commenting/TypeHintSniff.php
@@ -111,7 +111,7 @@ class TypeHintSniff implements Sniff
                 continue;
             }
 
-            $fix = $phpcsFile->addFixableWarning(
+            $fix = $phpcsFile->addFixableError(
                 '%s type hint is not formatted properly, expected "%s"',
                 $tag,
                 'IncorrectFormat',


### PR DESCRIPTION
Why are we using warnings in some cases where the expectation is to have it clearly fixed?
I would propose we fix those up to proper errors, as warnings are something very minor that usually also can be surpressed etc.