### PR TITLE
Improve TypeHint sniff.

### DIFF
--- a/CakePHP/Sniffs/Commenting/TypeHintSniff.php
+++ b/CakePHP/Sniffs/Commenting/TypeHintSniff.php
@@ -34,7 +34,7 @@ use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\PhpDocParser\Parser\TypeParser;
 
 /**
- * Verifies order of types in type hints
+ * Verifies order of types in type hints. Also removes duplicates.
  */
 class TypeHintSniff implements Sniff
 {
@@ -59,9 +59,42 @@ class TypeHintSniff implements Sniff
     ];
 
     /**
+     * Highest/First element will be first in list of param or return tag.
+     *
+     * @var array<string>
+     */
+    protected static $sortMap = [
+        '\\Closure',
+        '\\Traversable',
+        '\\ArrayAccess',
+        '\\ArrayObject',
+        '\\Stringable',
+        '\\Generator',
+        'mixed',
+        'callable',
+        'resource',
+        'object',
+        'iterable',
+        'list',
+        'array',
+        'callable-string',
+        'class-string',
+        'interface-string',
+        'scalar',
+        'string',
+        'float',
+        'int',
+        'bool',
+        'true',
+        'false',
+        'null',
+        'void',
+    ];
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
-     * @return array
+     * @inheritDoc
      */
     public function register()
     {
@@ -71,9 +104,7 @@ class TypeHintSniff implements Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int $stackPtr The position of the current token in the stack passed in $tokens.
-     * @return void
+     * @inheritDoc
      */
     public function process(File $phpcsFile, $stackPtr)
     {
@@ -86,19 +117,22 @@ class TypeHintSniff implements Sniff
         foreach ($tokens[$stackPtr]['comment_tags'] as $tag) {
             if (
                 $tokens[$tag + 2]['code'] !== T_DOC_COMMENT_STRING ||
-                !in_array($tokens[$tag]['content'], self::$typeHintTags, true)
+                !in_array($tokens[$tag]['content'], static::$typeHintTags, true)
             ) {
                 continue;
             }
 
             $tagComment = $phpcsFile->fixer->getTokenContent($tag + 2);
-            $valueNode = self::getValueNode($tokens[$tag]['content'], $tagComment);
+            $valueNode = static::getValueNode($tokens[$tag]['content'], $tagComment);
             if ($valueNode instanceof InvalidTagValueNode) {
                 continue;
             }
 
+            $hasUnion = false;
+            /** @var \PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode|\PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode $valueNode */
             if ($valueNode->type instanceof UnionTypeNode) {
                 $types = $valueNode->type->types;
+                $hasUnion = true;
             } elseif ($valueNode->type instanceof ArrayTypeNode) {
                 $types = [$valueNode->type];
             } else {
@@ -106,12 +140,12 @@ class TypeHintSniff implements Sniff
             }
 
             $originalTypeHint = $this->renderUnionTypes($types);
-            $sortedTypeHint = $this->getSortedTypeHint($types);
+            $sortedTypeHint = $this->getSortedTypeHint($types, $hasUnion);
             if ($sortedTypeHint === $originalTypeHint) {
                 continue;
             }
 
-            $fix = $phpcsFile->addFixableWarning(
+            $fix = $phpcsFile->addFixableError(
                 '%s type hint is not formatted properly, expected "%s"',
                 $tag,
                 'IncorrectFormat',
@@ -156,40 +190,12 @@ class TypeHintSniff implements Sniff
     }
 
     /**
-     * @param array $types node types
+     * @param array<\PHPStan\PhpDocParser\Ast\Type\TypeNode> $types node types
      * @return string
      */
-    protected function getSortedTypeHint(array $types): string
+    protected function getSortedTypeHint(array $types, bool $hasUnion): string
     {
-        static $shouldSort = [
-            '\\Closure',
-            '\\Traversable',
-            '\\ArrayAccess',
-            '\\ArrayObject',
-            '\\Stringable',
-            '\\Generator',
-            'mixed',
-            'callable',
-            'resource',
-            'object',
-            'iterable',
-            'list',
-            'array',
-            'callable-string',
-            'class-string',
-            'interface-string',
-            'scalar',
-            'string',
-            'float',
-            'int',
-            'bool',
-            'true',
-            'false',
-            'null',
-            'void',
-        ];
-
-        $sortable = array_fill_keys($shouldSort, []);
+        $sortable = array_fill_keys(static::$sortMap, []);
         $unsortable = [];
         foreach ($types as $type) {
             $sortName = null;
@@ -200,28 +206,33 @@ class TypeHintSniff implements Sniff
                     $sortName = $type->type->name;
                 }
             } elseif ($type instanceof ArrayTypeNode) {
-                if ($this->convertArraysToGenerics) {
+                if (!$this->convertArraysToGenerics) {
+                    $sortName = $type->type->name;
+                } elseif (!$this->isComplexObjectCollection($types, $hasUnion)) {
                     $type = new GenericTypeNode(new IdentifierTypeNode('array'), [$type->type]);
                     $sortName = 'array';
                 } elseif ($type->type instanceof IdentifierTypeNode) {
-                    $sortName = $type->type->name;
+                    $sortName = 'array';
                 } else {
                     $sortName = 'array';
                 }
             } elseif ($type instanceof ArrayShapeNode) {
                 $sortName = 'array';
             } elseif ($type instanceof GenericTypeNode) {
-                if (in_array($type->type->name, $shouldSort)) {
+                if (in_array($type->type->name, static::$sortMap)) {
                     $sortName = $type->type->name;
+                } else {
+                    $sortName = 'array';
                 }
             }
 
             if (!$sortName) {
                 $unsortable[] = $type;
+
                 continue;
             }
 
-            if (in_array($sortName, $shouldSort, true)) {
+            if (in_array($sortName, static::$sortMap, true)) {
                 if ($type instanceof ArrayTypeNode) {
                     array_unshift($sortable[$sortName], $type);
                 } else {
@@ -233,11 +244,14 @@ class TypeHintSniff implements Sniff
         }
 
         $sorted = [];
-        array_walk($sortable, function ($types) use (&$sorted) {
+        array_walk($sortable, function ($types) use (&$sorted): void {
             $sorted = array_merge($sorted, $types);
         });
 
-        return $this->renderUnionTypes(array_merge($unsortable, $sorted));
+        $types = array_merge($unsortable, $sorted);
+        $types = $this->makeUnique($types);
+
+        return $this->renderUnionTypes($types);
     }
 
     /**
@@ -246,7 +260,7 @@ class TypeHintSniff implements Sniff
      */
     protected function renderUnionTypes(array $typeNodes): string
     {
-        return preg_replace(
+        return (string)preg_replace(
             ['/ ([\|&]) /', '/<\(/', '/\)>/'],
             ['${1}', '<', '>'],
             implode('|', $typeNodes)
@@ -258,7 +272,7 @@ class TypeHintSniff implements Sniff
      * @param string $tagComment tag comment
      * @return \PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode
      */
-    protected static function getValueNode(string $tagName, $tagComment): PhpDocTagValueNode
+    protected static function getValueNode(string $tagName, string $tagComment): PhpDocTagValueNode
     {
         static $phpDocParser;
         if (!$phpDocParser) {
@@ -272,5 +286,48 @@ class TypeHintSniff implements Sniff
         }
 
         return $phpDocParser->parseTagValue(new TokenIterator($phpDocLexer->tokenize($tagComment)), $tagName);
+    }
+
+    /**
+     * @param array<\PHPStan\PhpDocParser\Ast\Type\TypeNode> $types
+     * @return array<\PHPStan\PhpDocParser\Ast\Type\TypeNode>
+     */
+    protected function makeUnique(array $types): array
+    {
+        $typesAsString = [];
+
+        foreach ($types as $key => $type) {
+            $type = (string)$type;
+            if (in_array($type, $typesAsString, true)) {
+                unset($types[$key]);
+
+                continue;
+            }
+            $typesAsString[] = $type;
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param array<\PHPStan\PhpDocParser\Ast\Type\TypeNode> $types
+     * @return bool
+     */
+    protected function isComplexObjectCollection(array $types, bool $isUnion): bool
+    {
+        if (!$isUnion) {
+        }
+
+        foreach ($types as $type) {
+            if (!$type instanceof IdentifierTypeNode) {
+                continue;
+            }
+
+            if (strpos((string)$type, '\\') === 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,14 @@
 # CakePHP ruleset
 
-The CakePHP standard contains 136 sniffs
+The CakePHP standard contains 140 sniffs
 
-CakePHP (19 sniffs)
+CakePHP (20 sniffs)
 -------------------
 - CakePHP.Classes.ReturnTypeHint
 - CakePHP.Commenting.DocBlockAlignment
 - CakePHP.Commenting.FunctionComment
 - CakePHP.Commenting.InheritDoc
+- CakePHP.Commenting.TypeHint
 - CakePHP.ControlStructures.ControlStructures
 - CakePHP.ControlStructures.ElseIfDeclaration
 - CakePHP.ControlStructures.WhileStructures
@@ -52,10 +53,9 @@ Generic (25 sniffs)
 - Generic.WhiteSpace.IncrementDecrementSpacing
 - Generic.WhiteSpace.ScopeIndent
 
-PEAR (2 sniffs)
+PEAR (1 sniff)
 ---------------
 - PEAR.Functions.ValidDefaultValue
-- PEAR.NamingConventions.ValidFunctionName
 
 PSR1 (3 sniffs)
 ---------------
@@ -94,7 +94,7 @@ PSR2 (9 sniffs)
 - PSR2.Methods.FunctionClosingBrace
 - PSR2.Methods.MethodDeclaration
 
-SlevomatCodingStandard (32 sniffs)
+SlevomatCodingStandard (37 sniffs)
 ----------------------------------
 - SlevomatCodingStandard.Arrays.TrailingArrayComma
 - SlevomatCodingStandard.Classes.ClassConstantVisibility
@@ -114,6 +114,7 @@ SlevomatCodingStandard (32 sniffs)
 - SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses
 - SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation
 - SlevomatCodingStandard.Namespaces.NamespaceDeclaration
+- SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
 - SlevomatCodingStandard.Namespaces.UnusedUses
 - SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash
 - SlevomatCodingStandard.Namespaces.UseFromSameNamespace
@@ -125,11 +126,15 @@ SlevomatCodingStandard (32 sniffs)
 - SlevomatCodingStandard.TypeHints.DeclareStrictTypes
 - SlevomatCodingStandard.TypeHints.LongTypeHints
 - SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue
+- SlevomatCodingStandard.TypeHints.ParameterTypeHint
 - SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing
+- SlevomatCodingStandard.TypeHints.PropertyTypeHint
+- SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing
+- SlevomatCodingStandard.TypeHints.ReturnTypeHint
 - SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
 - SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable
 
-Squiz (29 sniffs)
+Squiz (28 sniffs)
 -----------------
 - Squiz.Arrays.ArrayBracketSpacing
 - Squiz.Classes.ClassFileName
@@ -144,7 +149,6 @@ Squiz (29 sniffs)
 - Squiz.Functions.FunctionDeclarationArgumentSpacing
 - Squiz.Functions.LowercaseFunctionKeywords
 - Squiz.Functions.MultiLineFunctionDeclaration
-- Squiz.NamingConventions.ValidFunctionName
 - Squiz.Operators.ValidLogicalOperators
 - Squiz.PHP.DisallowSizeFunctionsInLoops
 - Squiz.PHP.Eval

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,4 +10,12 @@
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <severity>0</severity>
     </rule>
+
+    <!-- PHP 7.2 compatible code requires to disallow newer language elements -->
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall"/>
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Functions.DisallowNamedArguments"/>
+    <rule ref="SlevomatCodingStandard.Classes.DisallowConstructorPropertyPromotion"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowNullSafeObjectOperator"/>
+
 </ruleset>


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp-codesniffer/issues/347

Allows to keep

    \Object|type[]

for object collections as `\Object|array<type>` is wrong/invalid.
And we dont have a sniffer yet to ensure `\Object<type>` yet (which also isnt supported by IDEs like PHPStorm yet).