### PR TITLE
Allow \FQCN inside attributes

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -147,6 +147,9 @@
             <property name="allowFallbackGlobalConstants" type="boolean" value="true"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName">
+        <severity>0</severity>
+    </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/16222/files#r772373946

This is what we do to allow easier backwords compatible syntax for now.