### PR TITLE
Simplify test case for TypeHintSniff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       run: echo "::set-output name=date::$(date +'%Y-%m')"
 
     - name: Cache composer dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
@@ -57,7 +57,7 @@ jobs:
 
     - name: Configure PHPUnit matcher
       if: matrix.php-version == '7.4'
-      uses: mheap/phpunit-matcher-action@master
+      uses: mheap/phpunit-matcher-action@v1
 
     - name: Run PHPUnit
       run: |
@@ -92,7 +92,7 @@ jobs:
       run: echo "::set-output name=date::$(date +'%Y-%m')"
 
     - name: Cache composer dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}

--- a/CakePHP/Sniffs/Commenting/TypeHintSniff.php
+++ b/CakePHP/Sniffs/Commenting/TypeHintSniff.php
@@ -160,11 +160,12 @@ class TypeHintSniff implements Sniff
     {
         static $shouldSort = [
             '\\Closure',
-            '\\Traversable',
-            '\\ArrayAccess',
-            '\\ArrayObject',
-            '\\Stringable',
             '\\Generator',
+            '\\ArrayObject',
+            '\\ArrayAccess',
+            '\\Traversable',
+            '\\Stringable',
+            '\\Countable',
             '$this',
             'self',
             'mixed',

--- a/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc
+++ b/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc
@@ -4,39 +4,28 @@ namespace Beakman;
 class Foo
 {
     /** @var string[] */
-    protected $testVar;
+    protected $convertToGeneric;
 
-    /** @var null|string[]|class-string<\Cake\I18n\Number> $testVar2 */
-    protected $testVar2;
+    /** @var null|string[]|class-string<\Cake\I18n\Number>|\Generator<int> $testVar2 */
+    protected $sortGenerics;
+
+    /** @var string|array|array<int, string>|array{0: string, 1: int} */
+    protected $sortArrayShape
+
+    /** @var \Stringable|\Countable|\Traversable|\ArrayObject|\ArrayAccess|\Closure|\Generator|\CustomClass|string */
+    protected $sortSpecificClassesLast
 
     /**
      * @param \Test|\Closure|mixed|array<string|int>|string|int|false $test
-     * @psalm-param \Test|array<int, string>|array{0: string, 1: int}|string $test2
      * @return string|int|void
      */
-    public function testSortedCompound()
-    {
-    }
-
-    /**
-     * @param \Closure|\Test|mixed|int|false|string[]|array<string|int>|string $test
-     * @psalm-param string|list<int>|array{0: string, 1: int}|\Test $test2
-     * @return false|true|void|int|\Test|array<string>|int[]|null
-     * @psalm-return false|true|void|int|\Test|array<string>|int[]|null
-     */
-    public function testUnsortedCompound()
+    public function testFunctionAnotations()
     {
     }
 }
 
 function test()
 {
-    /** @var class-string<\Cake\I18n\Number>|null */
-    $testVar;
-
-    /** @psalm-var null|scalar|class-string<\Cake\I18n\Number>|array $testVar2 */
-    $testVar2;
-
-    /** @var string|null|array<string|int, array<mixed, array<string>|string|null>|string|null> */
-    $arrays;
+    /** @var null|string|int|float */
+    $testInlineVar;
 }

--- a/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc.fixed
+++ b/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc.fixed
@@ -4,39 +4,28 @@ namespace Beakman;
 class Foo
 {
     /** @var array<string> */
-    protected $testVar;
+    protected $convertToGeneric;
 
-    /** @var array<string>|class-string<\Cake\I18n\Number>|null $testVar2 */
-    protected $testVar2;
+    /** @var \Generator<int>|array<string>|class-string<\Cake\I18n\Number>|null $testVar2 */
+    protected $sortGenerics;
+
+    /** @var array|array<int, string>|array{0: string, 1: int}|string */
+    protected $sortArrayShape
+
+    /** @var \CustomClass|\Closure|\Generator|\ArrayObject|\ArrayAccess|\Traversable|\Stringable|\Countable|string */
+    protected $sortSpecificClassesLast
 
     /**
      * @param \Test|\Closure|mixed|array<string|int>|string|int|false $test
-     * @psalm-param \Test|array<int, string>|array{0: string, 1: int}|string $test2
      * @return string|int|void
      */
-    public function testSortedCompound()
-    {
-    }
-
-    /**
-     * @param \Test|\Closure|mixed|array<string>|array<string|int>|string|int|false $test
-     * @psalm-param \Test|list<int>|array{0: string, 1: int}|string $test2
-     * @return \Test|array<string>|array<int>|int|true|false|null|void
-     * @psalm-return \Test|array<string>|array<int>|int|true|false|null|void
-     */
-    public function testUnsortedCompound()
+    public function testFunctionAnotations()
     {
     }
 }
 
 function test()
 {
-    /** @var class-string<\Cake\I18n\Number>|null */
-    $testVar;
-
-    /** @psalm-var array|class-string<\Cake\I18n\Number>|scalar|null $testVar2 */
-    $testVar2;
-
-    /** @var array<string|int, array<mixed, array<string>|string|null>|string|null>|string|null */
-    $arrays;
+    /** @var string|float|int|null */
+    $testInlineVar;
 }

--- a/CakePHP/Tests/Commenting/TypeHintUnitTest.php
+++ b/CakePHP/Tests/Commenting/TypeHintUnitTest.php
@@ -27,12 +27,9 @@ class TypeHintUnitTest extends AbstractSniffUnitTest
                 return [
                     6 => 1,
                     9 => 1,
-                    22 => 1,
-                    23 => 1,
-                    24 => 1,
-                    25 => 1,
-                    37 => 1,
-                    40 => 1,
+                    12 => 1,
+                    15 => 1,
+                    29 => 1,
                 ];
 
             default:


### PR DESCRIPTION
Reduce the number of tests and make them more specific. Easier to read than the random set of types.