### PR TITLE
Seed files also lack namespace

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -23,6 +23,7 @@
     <!-- Relax rules from PSR12 -->
     <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
         <exclude-pattern>*/config/Migrations/*</exclude-pattern>
+        <exclude-pattern>*/config/Seeds/*</exclude-pattern>
     </rule>
     <rule ref="PSR1.Files.SideEffects">
         <exclude-pattern>*/config/*</exclude-pattern>


### PR DESCRIPTION
like Migrations https://github.com/cakephp/cakephp-codesniffer/pull/320
except class file name rule