### PR TITLE
Mark support for slevomat/coding-standard ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=7.2.0",
-        "slevomat/coding-standard": "^6.3.6 || ^7.0",
+        "slevomat/coding-standard": "^6.3.6 || ^7.0 || ^8.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "require-dev": {


### PR DESCRIPTION
PR marks compatibility of this library with the `^8.0` line of `slevomat/coding-standard`. The big reason (for me) to do this is that the 8.0.1 release of `slevomat/coding-standard` had a fix to work with the latest versions of phpstan, for the following runtime error:

```
PHP Fatal error:  Uncaught TypeError: Argument 5 passed to SlevomatCodingStandard\Helpers\Annotation\ParameterAnnotation::__construct() must be an instance of PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode or null, instance of PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode given, called in /home/runner/work/phinx/phinx/vendor/slevomat/coding-standard/SlevomatCodingStandard/Helpers/AnnotationHelper.php on line 357 and defined in /home/runner/work/phinx/phinx/vendor/slevomat/coding-standard/SlevomatCodingStandard/Helpers/Annotation/ParameterAnnotation.php:31
Stack trace:
#0 /home/runner/work/phinx/phinx/vendor/slevomat/coding-standard/SlevomatCodingStandard/Helpers/AnnotationHelper.php(357): SlevomatCodingStandard\Helpers\Annotation\ParameterAnnotation->__construct('@param', 74, 76, '$result', Object(PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode))
#1 /home/runner/work/phinx/phinx/vendor/slevomat/coding-standard/SlevomatCodingStandard/Helpers/SniffLocalCache.php(42): SlevomatCodingStandard\Helpers\Annota in /home/runner/work/phinx/phinx/vendor/slevomat/coding-standard/SlevomatCodingStandard/Helpers/Annotation/ParameterAnnotation.php on line 31
```

I checked and it does not look like this library makes use of any of the things that were removed in the [8.0.0 release](https://github.com/slevomat/coding-standard/releases/tag/8.0.0).