### PR TITLE
Bump up slevomat/coding-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=7.2.0",
         "phpstan/phpdoc-parser": "^1.4.5",
-        "slevomat/coding-standard": "^8.1",
+        "slevomat/coding-standard": "^8.4",
         "squizlabs/php_codesniffer": "^3.7.1"
     },
     "require-dev": {


### PR DESCRIPTION
8.4.0 fixes various issues with PHP 8.1