### PR TITLE
Add spacing check for arrow function closures.

### DIFF
--- a/CakePHP/Sniffs/Functions/ClosureDeclarationSniff.php
+++ b/CakePHP/Sniffs/Functions/ClosureDeclarationSniff.php
@@ -27,7 +27,7 @@ class ClosureDeclarationSniff implements Sniff
      */
     public function register()
     {
-        return [T_CLOSURE];
+        return [T_CLOSURE, T_FN];
     }
 
     /**
@@ -43,7 +43,8 @@ class ClosureDeclarationSniff implements Sniff
         }
 
         if ($spaces !== 1) {
-            $error = 'Expected 1 space after closure\'s function keyword; %s found';
+            $keyword = $tokens[$stackPtr]['code'] === T_FN ? 'fn' : 'function';
+            $error = "Expected 1 space after closure's $keyword keyword; %s found";
             $data = [$spaces];
             $phpcsFile->addError($error, $stackPtr, 'SpaceAfterFunction', $data);
         }

--- a/CakePHP/Tests/Functions/ClosureDeclarationUnitTest.inc
+++ b/CakePHP/Tests/Functions/ClosureDeclarationUnitTest.inc
@@ -21,6 +21,9 @@ class TraitUser
             echo 'It works';
         };
         $visitor($this);
+
+        $visitor = fn($expression) => echo 'It Fails';
+        $visitor = fn ($expression) => echo 'It works';
     }
 }
 

--- a/CakePHP/Tests/Functions/ClosureDeclarationUnitTest.php
+++ b/CakePHP/Tests/Functions/ClosureDeclarationUnitTest.php
@@ -13,7 +13,8 @@ class ClosureDeclarationUnitTest extends AbstractSniffUnitTest
     {
         return [
             17 => 1,
-            30 => 1,
+            25 => 1,
+            33 => 1,
         ];
     }
 


### PR DESCRIPTION
Currently core's 5.x codebase has a mix of `fn()` and `fn ()` so wanted to normalized that.