### PR TITLE
Update for PHP 8.1+

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ end_of_line = crlf
 
 [*.yml]
 indent_size = 2
+
+[*.neon]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,9 +11,11 @@
 
 # Ignore files for distribution archives, generated using `git archive`
 .editorconfig export-ignore
-.git export-ignore
+.github export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 phpcs.xml export-ignore
 phpunit.xml.dist export-ignore
 /CakePHP/Tests export-ignore
+phpstan.neon export-ignore
+.phive export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,17 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.1'
-        tools: cs2pr
+        tools: phive, cs2pr
         coverage: none
 
     - name: Composer install
       uses: ramsey/composer-install@v3
 
+    - name: Install PHP tools with phive.
+      run: "phive install --trust-gpg-keys 'CF1A108D0E7AE720,51C67305FFC2E5C0,12CE0F1D262429A5'"
+
     - name: Run PHP CodeSniffer
       run: vendor/bin/phpcs --report=checkstyle | cs2pr
 
     - name: Run PHPStan
-      run: vendor/bin/phpstan
+      run: tools/phpstan analyse --error-format=github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,6 @@ jobs:
 
     - name: Run PHP CodeSniffer
       run: vendor/bin/phpcs --report=checkstyle | cs2pr
+
+    - name: Run PHPStan
+      run: vendor/bin/phpstan

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+  <phar name="phpstan" version="2.0.3" installed="2.0.3" location="./tools/phpstan" copy="false"/>
+</phive>

--- a/CakePHP/Sniffs/Commenting/TypeHintSniff.php
+++ b/CakePHP/Sniffs/Commenting/TypeHintSniff.php
@@ -101,6 +101,7 @@ class TypeHintSniff implements Sniff
                 continue;
             }
 
+            /** @phpstan-ignore-next-line  */
             if ($valueNode->type instanceof UnionTypeNode) {
                 $types = $valueNode->type->types;
             } elseif ($valueNode->type instanceof ArrayTypeNode) {

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -98,6 +98,22 @@
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration">
+        <properties>
+            <property name="onlySingleLine" type="boolean" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse">
+        <properties>
+            <property name="onlySingleLine" type="boolean" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall">
+        <properties>
+            <property name="onlySingleLine" type="boolean" value="true"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility">
         <properties>
             <property name="fixable" type="boolean" value="true"/>

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -96,6 +96,8 @@
 
     <!-- Slevomat sniffs-->
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility">
         <properties>
             <property name="fixable" type="boolean" value="true"/>
@@ -141,6 +143,7 @@
     <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation">
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
+
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
         <properties>

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -133,17 +133,17 @@
     <rule ref="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
         <properties>
-            <property name="linesCountBeforeFirstContent" value="0" />
-            <property name="linesCountBetweenDescriptionAndAnnotations" value="1" />
-            <property name="linesCountBetweenDifferentAnnotationsTypes" value="0" />
-            <property name="linesCountBetweenAnnotationsGroups" value="0" />
-            <property name="linesCountAfterLastContent" value="0" />
+            <property name="linesCountBeforeFirstContent" value="0"/>
+            <property name="linesCountBetweenDescriptionAndAnnotations" value="1"/>
+            <property name="linesCountBetweenDifferentAnnotationsTypes" value="0"/>
+            <property name="linesCountBetweenAnnotationsGroups" value="0"/>
+            <property name="linesCountAfterLastContent" value="0"/>
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration">
         <properties>
-            <property name="allowDocCommentAboveReturn" type="boolean" value="true" />
+            <property name="allowDocCommentAboveReturn" type="boolean" value="true"/>
         </properties>
         <exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.NoAssignment"/>
         <exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable"/>
@@ -232,13 +232,13 @@
     <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
     <rule ref="SlevomatCodingStandard.Variables.UnusedVariable">
         <properties>
-            <property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true" />
+            <property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true"/>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration" />
+    <rule ref="SlevomatCodingStandard.Functions.NamedArgumentSpacing"/>
+    <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration"/>
     <rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing"/>
     <rule ref="SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment"/>
-    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
 
     <!-- phpcs Zend sniffs -->
     <rule ref="Zend.NamingConventions.ValidVariableName">

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "squizlabs/php_codesniffer": "^3.9"
     },
     "require-dev": {
-        "phpstan/phpstan": "^2.0.3",
         "phpunit/phpunit": "^9.3.4"
     },
     "autoload": {
@@ -46,7 +45,7 @@
         ],
         "cs-check": "phpcs --colors --parallel=16 -p -s CakePHP/",
         "cs-fix": "phpcbf --colors --parallel=16 -p CakePHP/",
-        "stan": "phpstan analyse",
+        "stan": "tools/phpstan analyse",
         "docs": "php docs/generate.php",
         "explain": "phpcs -e --standard=CakePHP"
     }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "squizlabs/php_codesniffer": "^3.9"
     },
     "require-dev": {
+        "phpstan/phpstan": "^2.0.3",
         "phpunit/phpunit": "^9.3.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         ],
         "cs-check": "phpcs --colors --parallel=16 -p -s CakePHP/",
         "cs-fix": "phpcbf --colors --parallel=16 -p CakePHP/",
+        "stan": "phpstan analyse",
         "docs": "php docs/generate.php",
         "explain": "phpcs -e --standard=CakePHP"
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # CakePHP ruleset
 
-The CakePHP standard contains 147 sniffs
+The CakePHP standard contains 152 sniffs
 
 CakePHP (20 sniffs)
 -------------------
@@ -95,7 +95,7 @@ PSR12 (17 sniffs)
 - PSR12.Properties.ConstantVisibility
 - PSR12.Traits.UseDeclaration
 
-SlevomatCodingStandard (43 sniffs)
+SlevomatCodingStandard (48 sniffs)
 ----------------------------------
 - SlevomatCodingStandard.Arrays.TrailingArrayComma
 - SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing
@@ -116,7 +116,12 @@ SlevomatCodingStandard (43 sniffs)
 - SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator
 - SlevomatCodingStandard.Exceptions.DeadCatch
 - SlevomatCodingStandard.Functions.ArrowFunctionDeclaration
+- SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall
+- SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse
+- SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration
 - SlevomatCodingStandard.Functions.RequireTrailingCommaInCall
+- SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse
+- SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration
 - SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses
 - SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation
 - SlevomatCodingStandard.Namespaces.NamespaceDeclaration

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # CakePHP ruleset
 
-The CakePHP standard contains 152 sniffs
+The CakePHP standard contains 153 sniffs
 
 CakePHP (20 sniffs)
 -------------------
@@ -95,7 +95,7 @@ PSR12 (17 sniffs)
 - PSR12.Properties.ConstantVisibility
 - PSR12.Traits.UseDeclaration
 
-SlevomatCodingStandard (48 sniffs)
+SlevomatCodingStandard (49 sniffs)
 ----------------------------------
 - SlevomatCodingStandard.Arrays.TrailingArrayComma
 - SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing
@@ -119,6 +119,7 @@ SlevomatCodingStandard (48 sniffs)
 - SlevomatCodingStandard.Functions.DisallowTrailingCommaInCall
 - SlevomatCodingStandard.Functions.DisallowTrailingCommaInClosureUse
 - SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration
+- SlevomatCodingStandard.Functions.NamedArgumentSpacing
 - SlevomatCodingStandard.Functions.RequireTrailingCommaInCall
 - SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse
 - SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+	level: 6
+	paths:
+		- CakePHP/Sniffs/
+	bootstrapFiles:
+		- %rootDir%/../../../tests/phpstan_bootstrap.php
+	ignoreErrors:
+
+	checkMissingIterableValueType: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,6 @@ parameters:
 	paths:
 		- CakePHP/Sniffs/
 	bootstrapFiles:
-		- %rootDir%/../../../tests/phpstan_bootstrap.php
+		- tests/phpstan_bootstrap.php
 	ignoreErrors:
 		- identifier: missingType.iterableValue

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,5 +5,4 @@ parameters:
 	bootstrapFiles:
 		- %rootDir%/../../../tests/phpstan_bootstrap.php
 	ignoreErrors:
-
-	checkMissingIterableValueType: false
+		- identifier: missingType.iterableValue

--- a/tests/phpstan_bootstrap.php
+++ b/tests/phpstan_bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+$manualAutoload = dirname(__DIR__) . '/vendor/squizlabs/php_codesniffer/autoload.php';
+if (!class_exists(\PHP_CodeSniffer\Config::class) && file_exists($manualAutoload)) {
+    require $manualAutoload;
+}
+\PHP_CodeSniffer\Autoload::load('PHP_CodeSniffer\Util\Tokens');


### PR DESCRIPTION
First stab at https://github.com/cakephp/cakephp-codesniffer/issues/368

It will also require test harness to be fixed up for 8.1+

> Declaration of PHP_CodeSniffer\Tests\TestSuite::run(?PHPUnit\Framework\TestResult $result = null) must be compatible with PHPUnit\Framework\TestSuite::run(?PHPUnit\Framework\TestResult $result = null): PHPUnit\Framework\TestResult

As well as (follow-ups?):
- Move tests into tests/ with proper autoload-dev instead of part of autoload