### PR TITLE
Update ruleset.xml

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -163,9 +163,6 @@
             <property name="linesCountBeforeDeclare" value="0"/>
             <property name="linesCountAfterDeclare" value="1"/>
             <property name="spacesCountAroundEqualsSign" value="0"/>
-            <!-- Property names used in slevomat/coding-standard v6 -->
-            <property name="newlinesCountAfterDeclare" value="2"/>
-            <property name="newlinesCountBetweenOpenTagAndDeclare" value="1"/>
         </properties>
         <exclude-pattern>*/config/*</exclude-pattern>
         <exclude-pattern>*/templates/*</exclude-pattern>

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -193,7 +193,6 @@
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
         <properties>
             <property name="enableMixedTypeHint" type="boolean" value="true"/>
-            <property name="enableStaticTypeHint" type="boolean" value="true"/>
             <property name="enableUnionTypeHint" type="boolean" value="true"/>
         </properties>
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>


### PR DESCRIPTION
v5 is not allowing slevomat/coding-standard v6 and it's giving deprecation errors in newer versions of php.

Deprecated: Creation of dynamic property SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff::$newlinesCountAfterDeclare is deprecated

ref: https://github.com/squizlabs/PHP_CodeSniffer/pull/3629#issuecomment-1500485945

the propertytypehint sniff has no enableStaticTypeHint option:

https://github.com/slevomat/coding-standard/blob/master/SlevomatCodingStandard/Sniffs/TypeHints/PropertyTypeHintSniff.php#L68