### PR TITLE
drop support for slevomat/coding-standard v6

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -154,9 +154,6 @@
             <property name="linesCountBeforeDeclare" value="0"/>
             <property name="linesCountAfterDeclare" value="1"/>
             <property name="spacesCountAroundEqualsSign" value="0"/>
-            <!-- Property names used in slevomat/coding-standard v6 -->
-            <property name="newlinesCountAfterDeclare" value="2"/>
-            <property name="newlinesCountBetweenOpenTagAndDeclare" value="1"/>
         </properties>
         <exclude-pattern>*/config/*</exclude-pattern>
         <exclude-pattern>*/templates/*</exclude-pattern>

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=7.2.0",
-        "slevomat/coding-standard": "^6.3.6 || ^7.0 || ^8.0",
+        "slevomat/coding-standard": "^7.0 || ^8.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "require-dev": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # CakePHP ruleset
 
-The CakePHP standard contains 136 sniffs
+The CakePHP standard contains 135 sniffs
 
 CakePHP (19 sniffs)
 -------------------
@@ -52,10 +52,9 @@ Generic (25 sniffs)
 - Generic.WhiteSpace.IncrementDecrementSpacing
 - Generic.WhiteSpace.ScopeIndent
 
-PEAR (2 sniffs)
+PEAR (1 sniff)
 ---------------
 - PEAR.Functions.ValidDefaultValue
-- PEAR.NamingConventions.ValidFunctionName
 
 PSR1 (3 sniffs)
 ---------------
@@ -63,11 +62,12 @@ PSR1 (3 sniffs)
 - PSR1.Files.SideEffects
 - PSR1.Methods.CamelCapsMethodName
 
-PSR12 (16 sniffs)
+PSR12 (17 sniffs)
 -----------------
 - PSR12.Classes.AnonClassDeclaration
 - PSR12.Classes.ClassInstantiation
 - PSR12.Classes.ClosingBrace
+- PSR12.Classes.OpeningBraceSpace
 - PSR12.ControlStructures.BooleanOperatorPlacement
 - PSR12.ControlStructures.ControlStructureSpacing
 - PSR12.Files.DeclareStatement
@@ -129,7 +129,7 @@ SlevomatCodingStandard (32 sniffs)
 - SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
 - SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable
 
-Squiz (29 sniffs)
+Squiz (28 sniffs)
 -----------------
 - Squiz.Arrays.ArrayBracketSpacing
 - Squiz.Classes.ClassFileName
@@ -144,7 +144,6 @@ Squiz (29 sniffs)
 - Squiz.Functions.FunctionDeclarationArgumentSpacing
 - Squiz.Functions.LowercaseFunctionKeywords
 - Squiz.Functions.MultiLineFunctionDeclaration
-- Squiz.NamingConventions.ValidFunctionName
 - Squiz.Operators.ValidLogicalOperators
 - Squiz.PHP.DisallowSizeFunctionsInLoops
 - Squiz.PHP.Eval


### PR DESCRIPTION
https://github.com/cakephp/cakephp-codesniffer/issues/382