### PR TITLE
5.x dependencies update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.2']
+        php-version: ['8.1', '8.2', '8.3']
         dependencies: ['highest']
         include:
           - php-version: '8.1'
             dependencies: 'lowest'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -31,7 +31,7 @@ jobs:
         coverage: none
 
     - name: Composer install
-      uses: ramsey/composer-install@v2
+      uses: ramsey/composer-install@v3
       with:
         dependency-versions: ${{ matrix.dependencies }}
         composer-options: --ignore-platform-reqs
@@ -54,7 +54,7 @@ jobs:
         coverage: none
 
     - name: Composer install
-      uses: ramsey/composer-install@v2
+      uses: ramsey/composer-install@v3
       with:
         composer-options: --ignore-platform-reqs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
       uses: ramsey/composer-install@v3
       with:
         dependency-versions: ${{ matrix.dependencies }}
-        composer-options: --ignore-platform-reqs
 
     - name: Run PHPUnit
       run: composer phpunit
@@ -55,8 +54,6 @@ jobs:
 
     - name: Composer install
       uses: ramsey/composer-install@v3
-      with:
-        composer-options: --ignore-platform-reqs
 
     - name: Run PHP CodeSniffer
       run: vendor/bin/phpcs --report=checkstyle | cs2pr

--- a/CakePHP/Sniffs/Classes/ReturnTypeHintSniff.php
+++ b/CakePHP/Sniffs/Classes/ReturnTypeHintSniff.php
@@ -58,7 +58,7 @@ class ReturnTypeHintSniff implements Sniff
 
         // We skip for interface methods
         if (empty($tokens[$stackPtr]['scope_opener']) || empty($tokens[$stackPtr]['scope_closer'])) {
-            return [];
+            return;
         }
 
         $returnTokenCode = $tokens[$startIndex]['code'];

--- a/CakePHP/Tests/Classes/ReturnTypeHintUnitTest.inc.fixed
+++ b/CakePHP/Tests/Classes/ReturnTypeHintUnitTest.inc.fixed
@@ -1,9 +1,6 @@
 <?php
 namespace Beakman;
 
-use Other\Crap;
-use Other\Error as OtherError;
-
 class Foo
 {
     /**

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -216,6 +216,7 @@
             <property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true" />
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration" />
 
     <!-- phpcs Zend sniffs -->
     <rule ref="Zend.NamingConventions.ValidVariableName">

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     "require": {
         "php": ">=8.1.0",
         "phpstan/phpdoc-parser": "^1.4.5",
-        "slevomat/coding-standard": "^8.4",
-        "squizlabs/php_codesniffer": "^3.7.1"
+        "slevomat/coding-standard": "^8.15",
+        "squizlabs/php_codesniffer": "^3.9"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.1"
+        "phpunit/phpunit": "^9.3.4"
     },
     "autoload": {
         "psr-4": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Generic (25 sniffs)
 - Generic.WhiteSpace.ScopeIndent
 
 PEAR (1 sniff)
----------------
+--------------
 - PEAR.Functions.ValidDefaultValue
 
 PSR1 (3 sniffs)
@@ -62,6 +62,18 @@ PSR1 (3 sniffs)
 - PSR1.Classes.ClassDeclaration
 - PSR1.Files.SideEffects
 - PSR1.Methods.CamelCapsMethodName
+
+PSR2 (9 sniffs)
+---------------
+- PSR2.Classes.ClassDeclaration
+- PSR2.Classes.PropertyDeclaration
+- PSR2.ControlStructures.ElseIfDeclaration
+- PSR2.ControlStructures.SwitchDeclaration
+- PSR2.Files.ClosingTag
+- PSR2.Files.EndFileNewline
+- PSR2.Methods.FunctionCallSignature
+- PSR2.Methods.FunctionClosingBrace
+- PSR2.Methods.MethodDeclaration
 
 PSR12 (17 sniffs)
 -----------------
@@ -82,18 +94,6 @@ PSR12 (17 sniffs)
 - PSR12.Operators.OperatorSpacing
 - PSR12.Properties.ConstantVisibility
 - PSR12.Traits.UseDeclaration
-
-PSR2 (9 sniffs)
----------------
-- PSR2.Classes.ClassDeclaration
-- PSR2.Classes.PropertyDeclaration
-- PSR2.ControlStructures.ElseIfDeclaration
-- PSR2.ControlStructures.SwitchDeclaration
-- PSR2.Files.ClosingTag
-- PSR2.Files.EndFileNewline
-- PSR2.Methods.FunctionCallSignature
-- PSR2.Methods.FunctionClosingBrace
-- PSR2.Methods.MethodDeclaration
 
 SlevomatCodingStandard (40 sniffs)
 ----------------------------------
@@ -170,5 +170,5 @@ Squiz (28 sniffs)
 - Squiz.WhiteSpace.SuperfluousWhitespace
 
 Zend (1 sniff)
----------------
+--------------
 - Zend.NamingConventions.ValidVariableName

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # CakePHP ruleset
 
-The CakePHP standard contains 143 sniffs
+The CakePHP standard contains 144 sniffs
 
 CakePHP (20 sniffs)
 -------------------
@@ -95,7 +95,7 @@ PSR2 (9 sniffs)
 - PSR2.Methods.FunctionClosingBrace
 - PSR2.Methods.MethodDeclaration
 
-SlevomatCodingStandard (39 sniffs)
+SlevomatCodingStandard (40 sniffs)
 ----------------------------------
 - SlevomatCodingStandard.Arrays.TrailingArrayComma
 - SlevomatCodingStandard.Classes.ClassConstantVisibility
@@ -113,6 +113,7 @@ SlevomatCodingStandard (39 sniffs)
 - SlevomatCodingStandard.ControlStructures.NewWithParentheses
 - SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator
 - SlevomatCodingStandard.Exceptions.DeadCatch
+- SlevomatCodingStandard.Functions.ArrowFunctionDeclaration
 - SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses
 - SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation
 - SlevomatCodingStandard.Namespaces.NamespaceDeclaration


### PR DESCRIPTION
Updated dependencies and `composer install` now works without having to ignore platform deps.