### PR TITLE
add attribute rules

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -217,6 +217,8 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration" />
+    <rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing"/>
+    <rule ref="SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment"/>
 
     <!-- phpcs Zend sniffs -->
     <rule ref="Zend.NamingConventions.ValidVariableName">


### PR DESCRIPTION
This makes sure that something like this is not allowed:
```
#[DataProvider('irregularCreateTableProvider')] public function mymethod(): void
```

This also forces attribtues to be added bellow the docblock

Refs: https://github.com/cakephp/migrations/pull/736