### PR TITLE
fix error when phpdoc param has no type

### DIFF
--- a/CakePHP/Sniffs/Commenting/TypeHintSniff.php
+++ b/CakePHP/Sniffs/Commenting/TypeHintSniff.php
@@ -101,11 +101,16 @@ class TypeHintSniff implements Sniff
                 continue;
             }
 
-            if ($valueNode->type instanceof UnionTypeNode) {
-                $types = $valueNode->type->types;
-            } elseif ($valueNode->type instanceof ArrayTypeNode) {
-                $types = [$valueNode->type];
+            if (isset($valueNode->type)) {
+                if ($valueNode->type instanceof UnionTypeNode) {
+                    $types = $valueNode->type->types;
+                } elseif ($valueNode->type instanceof ArrayTypeNode) {
+                    $types = [$valueNode->type];
+                } else {
+                    continue;
+                }
             } else {
+                $phpcsFile->addWarning('@param type hint is missing', $tag, 'MissingParamType');
                 continue;
             }
 

--- a/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc
+++ b/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc
@@ -22,6 +22,14 @@ class Foo
     public function testFunctionAnotations()
     {
     }
+
+    /**
+     * @param $test
+     * @return void
+     */
+    public function testNoParamTypeHint(string $test)
+    {
+    }
 }
 
 function test()

--- a/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc.fixed
+++ b/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc.fixed
@@ -22,6 +22,14 @@ class Foo
     public function testFunctionAnotations()
     {
     }
+
+    /**
+     * @param $test
+     * @return void
+     */
+    public function testNoParamTypeHint(string $test)
+    {
+    }
 }
 
 function test()

--- a/CakePHP/Tests/Commenting/TypeHintUnitTest.php
+++ b/CakePHP/Tests/Commenting/TypeHintUnitTest.php
@@ -29,8 +29,9 @@ class TypeHintUnitTest extends AbstractSniffUnitTest
                     9 => 1,
                     12 => 1,
                     15 => 1,
-                    29 => 1,
-                    34 => 1,
+                    27 => 1,
+                    37 => 1,
+                    42 => 1,
                 ];
 
             default:


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp-codesniffer/issues/402

This adds a new warning if a param type has no type hint instead of just bailing out due to an error