### PR TITLE
error on group use declarations

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -148,6 +148,7 @@
             <property name="allowFallbackGlobalConstants" type="boolean" value="true"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp-codesniffer/issues/401

This now properly causes
```
--------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------------
 30 | ERROR | [ ] Group use declaration is disallowed, use single use for every
    |       |     import.
 31 | ERROR | [x] Expected 0 lines between same types of use statement, found
    |       |     1.
--------------------------------------------------------------------------------
```

for 
```
use App\Utility\FTP\{AlfredFTP, AlfredFTPInterface};
```