### PR TITLE
fix error with change in slevomat/coding-standard 8.19.0

### DIFF
--- a/CakePHP/Sniffs/Classes/ReturnTypeHintSniff.php
+++ b/CakePHP/Sniffs/Classes/ReturnTypeHintSniff.php
@@ -228,7 +228,10 @@ class ReturnTypeHintSniff implements Sniff
             return null;
         }
 
-        $classPointer = $phpCsFile->findPrevious(TokenHelper::$typeKeywordTokenCodes, $lastToken);
+        $classPointer = $phpCsFile->findPrevious(
+            [T_CLASS, T_TRAIT, T_INTERFACE, T_ENUM],
+            $lastToken,
+        );
         if (!$classPointer) {
             return null;
         }


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp-codesniffer/issues/415

Instead of relying again on the new property `CLASS_TYPE_TOKEN_CODES` I just copied it over to make it BC compatible