### PR TITLE
fix error with change in slevomat/coding-standard 8.19.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.4', '8.0']
-        prefer-lowest: ['']
+        php-version: ['7.2', '7.4']
+        dependencies: [highest]
         include:
           - php-version: '7.2'
-            prefer-lowest: 'prefer-lowest'
+            dependencies: 'lowest'
+          - php-version: '8.0'
+            composer-options: "--ignore-platform-reqs"
 
     steps:
     - uses: actions/checkout@v2
@@ -30,29 +32,11 @@ jobs:
         extensions: mbstring, intl
         coverage: pcov
 
-    - name: Get composer cache directory
-      id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-    - name: Get date part for cache key
-      id: key-date
-      run: echo "::set-output name=date::$(date +'%Y-%m')"
-
-    - name: Cache composer dependencies
-      uses: actions/cache@v1
+    - name: Composer install
+      uses: ramsey/composer-install@v3
       with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
-
-    - name: Composer Install
-      run: |
-        if [[ ${{ matrix.php-version }} == '8.0' ]]; then
-          composer install --ignore-platform-reqs
-        elif ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
-          composer update --prefer-lowest --prefer-stable
-        else
-          composer install
-        fi
+        dependency-versions: ${{ matrix.dependencies }}
+        composer-options: "${{ matrix.composer-options }}"
 
     - name: Setup problem matchers for PHPUnit
       if: matrix.php-version == '7.4'
@@ -82,22 +66,8 @@ jobs:
         tools: cs2pr
         coverage: none
 
-    - name: Get composer cache directory
-      id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-    - name: Get date part for cache key
-      id: key-date
-      run: echo "::set-output name=date::$(date +'%Y-%m')"
-
-    - name: Cache composer dependencies
-      uses: actions/cache@v1
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
-
     - name: Composer install
-      run: composer install
+      uses: ramsey/composer-install@v3
 
     - name: Run PHP CodeSniffer
       run: vendor/bin/phpcs --report=checkstyle CakePHP/ | cs2pr

--- a/CakePHP/Sniffs/Classes/ReturnTypeHintSniff.php
+++ b/CakePHP/Sniffs/Classes/ReturnTypeHintSniff.php
@@ -230,7 +230,7 @@ class ReturnTypeHintSniff implements Sniff
 
         return ClassHelper::getFullyQualifiedName(
             $phpCsFile,
-            $phpCsFile->findPrevious(TokenHelper::$typeKeywordTokenCodes, $lastToken)
+            $phpCsFile->findPrevious([T_CLASS, T_TRAIT, T_INTERFACE, T_ENUM], $lastToken)
         );
     }
 }

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -51,10 +51,15 @@
         </properties>
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
-    <rule ref="Generic.Formatting.NoSpaceAfterCast"/>
+    <rule ref="Generic.Formatting.SpaceAfterCast">
+        <properties>
+            <property name="spacing" value="0"/>
+        </properties>
+    </rule>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.PHP.ForbiddenFunctions"/>
     <rule ref="Generic.PHP.NoSilencedErrors"/>
+    <rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
 
     <!-- Relax CakePHP rules -->
     <rule ref="CakePHP.Commenting.FunctionComment">
@@ -81,7 +86,6 @@
     <rule ref="Squiz.Scope.MemberVarScope"/>
     <rule ref="Squiz.Scope.StaticThisUsage"/>
     <rule ref="Squiz.WhiteSpace.CastSpacing"/>
-    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>


### PR DESCRIPTION
Closes #418

* backports the fix from https://github.com/cakephp/cakephp-codesniffer/issues/415 to 4.x
* updates CI to not use actions/cache@v1 which breaks CI
* updates ruleset to not use deprecated sniffs