### PR TITLE
Fix conflict between TypeHintSniff and Slevomat null position sniffs

### DIFF
--- a/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc
+++ b/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc
@@ -45,3 +45,12 @@ function test()
 function intersection($param)
 {
 }
+
+/**
+ * Void must be last, after null.
+ *
+ * @return int|void|null
+ */
+function voidAfterNull()
+{
+}

--- a/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc.fixed
+++ b/CakePHP/Tests/Commenting/TypeHintUnitTest.1.inc.fixed
@@ -45,3 +45,12 @@ function test()
 function intersection($param)
 {
 }
+
+/**
+ * Void must be last, after null.
+ *
+ * @return int|null|void
+ */
+function voidAfterNull()
+{
+}

--- a/CakePHP/Tests/Commenting/TypeHintUnitTest.php
+++ b/CakePHP/Tests/Commenting/TypeHintUnitTest.php
@@ -32,6 +32,7 @@ class TypeHintUnitTest extends AbstractSniffTestCase
                     27 => 1,
                     37 => 1,
                     42 => 1,
+                    52 => 1,
                 ];
 
             default:

--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -233,7 +233,6 @@
             <property name="withSpacesAroundOperators" value="no"/>
             <property name="withSpacesInsideParentheses" value="no"/>
             <property name="shortNullable" value="yes"/>
-            <property name="nullPosition" value="last"/>
         </properties>
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
@@ -258,7 +257,6 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator"/>
     <rule ref="SlevomatCodingStandard.Classes.RequireSelfReference"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
 
     <!-- phpcs Zend sniffs -->
     <rule ref="Zend.NamingConventions.ValidVariableName">


### PR DESCRIPTION
## Summary

- Remove `NullTypeHintOnLastPosition` sniff from ruleset
- Remove `nullPosition="last"` property from `DNFTypeHintFormat` sniff

This fixes the conflict where CakePHP's `TypeHintSniff` expects `void` to be last in union types (e.g., `int|null|void`), but Slevomat sniffs enforced `null` as last position (expecting `int|void|null`).

The conflict caused PHPCBF to fail when trying to fix files containing both `null` and `void` in union types, as both sniffs would fight each other.

This follows the same approach as [php-collective/code-sniffer](https://github.com/php-collective/code-sniffer) which also doesn't use these Slevomat sniffs.

Fixes #426