### PR TITLE
[5.x] Fix conflict between TypeHintSniff and Slevomat null position sniff

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -234,7 +234,6 @@
             <property name="withSpacesAroundOperators" value="no"/>
             <property name="withSpacesInsideParentheses" value="no"/>
             <property name="shortNullable" value="yes"/>
-            <property name="nullPosition" value="last"/>
         </properties>
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>


### PR DESCRIPTION
## Summary

- Remove `nullPosition="last"` property from `DNFTypeHintFormat` sniff

This fixes the conflict where CakePHP's `TypeHintSniff` expects `void` to be last in union types (e.g., `int|null|void`), but Slevomat's `nullPosition="last"` enforced `null` as last position (expecting `int|void|null`).

Backport of #427 for 5.x branch.

Fixes #426