### PR TITLE
Disallow partial uses in ReferenceUsedNamesOnly

### DIFF
--- a/CakePHP/ruleset.xml
+++ b/CakePHP/ruleset.xml
@@ -173,6 +173,7 @@
         <properties>
             <property name="allowFallbackGlobalFunctions" type="boolean" value="true"/>
             <property name="allowFallbackGlobalConstants" type="boolean" value="true"/>
+            <property name="allowPartialUses" type="boolean" value="false"/>
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>


### PR DESCRIPTION
Fixes #430.

Partial namespace references like `Mockery\MockInterface` (as opposed to the FQCN form `\Mockery\MockInterface`) were not flagged by `SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly` because Slevomat's `allowPartialUses` property defaults to `true`.

Setting it to `false` makes the sniff flag such references so they must be imported via a `use` statement.

## Before

```php
namespace App\Test;

class FooTest {
    public function bar(Mockery\MockInterface $x): void {}  // not flagged
}
```

## After

```
ERROR | Partial use statements are not allowed, but referencing Mockery\MockInterface found.
```

The FQCN form (`\Mockery\MockInterface`) was and remains flagged by the same sniff.

Note: this is a behavior-tightening change. Downstream code that intentionally uses partial imports would be affected - but I guess thats fair enough as they could change it back themselves.