### PR TITLE
Skip Missing doc comment when signature is fully typed

### DIFF
--- a/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
@@ -62,12 +62,14 @@ class FunctionCommentSniff implements Sniff
             null,
         );
         if ($docCommentEnd === false || $tokens[$docCommentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
-            $phpcsFile->addError(
-                'Missing doc comment for function %s()',
-                $stackPtr,
-                'Missing',
-                [$phpcsFile->getDeclarationName($stackPtr)],
-            );
+            if (!$this->hasFullNativeTypes($phpcsFile, $stackPtr)) {
+                $phpcsFile->addError(
+                    'Missing doc comment for function %s()',
+                    $stackPtr,
+                    'Missing',
+                    [$phpcsFile->getDeclarationName($stackPtr)],
+                );
+            }
 
             return;
         }
@@ -105,6 +107,38 @@ class FunctionCommentSniff implements Sniff
         $commentStart = $tokens[$docCommentEnd]['comment_opener'];
         $this->processTagSpacing($phpcsFile, $stackPtr, $commentStart);
         $this->processThrows($phpcsFile, $stackPtr, $commentStart);
+    }
+
+    /**
+     * Checks whether the function has a native return type (or is a constructor)
+     * and every parameter has a native type declaration. A docblock is considered
+     * redundant in that case since all type information is already expressed in
+     * the signature.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+     * @return bool
+     */
+    protected function hasFullNativeTypes(File $phpcsFile, int $stackPtr): bool
+    {
+        $name = $phpcsFile->getDeclarationName($stackPtr);
+        $isConstructor = strtolower((string)$name) === '__construct';
+
+        if (!$isConstructor) {
+            $properties = $phpcsFile->getMethodProperties($stackPtr);
+            if (($properties['return_type'] ?? '') === '') {
+                return false;
+            }
+        }
+
+        $parameters = $phpcsFile->getMethodParameters($stackPtr);
+        foreach ($parameters as $parameter) {
+            if (($parameter['type_hint'] ?? '') === '') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.1.inc
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.1.inc
@@ -97,4 +97,22 @@ class Foo
         throw new \RuntimeException();
         return;
     }
+
+    public function fullyTyped(int $a, string $b): void
+    {
+    }
+
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name,
+    ) {
+    }
+
+    public function noReturnType(int $a)
+    {
+    }
+
+    public function missingParamType($a): void
+    {
+    }
 }

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.php
@@ -20,6 +20,8 @@ class FunctionCommentUnitTest extends AbstractSniffTestCase
                     41 => 1,
                     50 => 1,
                     58 => 1,
+                    111 => 1,
+                    115 => 1,
                 ];
 
             default:


### PR DESCRIPTION
## Summary

The `CakePHP.Commenting.FunctionComment.Missing` sniff currently flags every function without a docblock, even when the signature already expresses all type information natively. With constructor property promotion this is especially noisy:

```php
final readonly class TenancySlice
{
    public function __construct(
        public string $x,
        public Decimal $y,
        public int $z,
    ) {
    }
}
```

Every parameter is already visibility-, type- and name-declared inline; a docblock would be pure redundancy.

This PR teaches the sniff to skip the \`Missing\` error when the function signature carries full native type information:

- \`__construct\` — skipped if every parameter has a native type (constructors cannot declare a return type).
- Any other function — skipped if it has a native return type **and** every parameter has a native type.

Functions that still lack types (untyped params, missing return types) continue to require a docblock, so legacy code is unaffected.

Other existing checks (spacing after docblock, \`@throws\` validation, etc.) are unchanged and still run whenever a docblock *is* present.
