### PR TITLE
[4.x] Add support for multiple attribute lines to Commenting.FunctionComment

### DIFF
--- a/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/CakePHP/Sniffs/Commenting/FunctionCommentSniff.php
@@ -119,7 +119,7 @@ class FunctionCommentSniff implements Sniff
             && $tokens[$commentEnd]['code'] !== T_COMMENT
         ) {
             $previous = $commentEnd;
-            if (
+            while (
                 $tokens[$commentEnd]['code'] === T_ATTRIBUTE_END
                 || $tokens[$commentEnd]['code'] === T_ATTRIBUTE
             ) {

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -239,4 +239,17 @@ class Foo
     public function returnWillChange($param, $otherParam)
     {
     }
+
+    /**
+     * Some sentence.
+     *
+     * @param int $param Some Param.
+     * @param bool $otherParam Some Other Param.
+     * @return string Something.
+     */
+    #[ReturnTypeWillChange]
+    #[NoDiscard]
+    public function withMultipleAttributes($param, $otherParam)
+    {
+    }
 }

--- a/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
+++ b/CakePHP/Tests/Commenting/FunctionCommentUnitTest.inc.fixed
@@ -239,4 +239,17 @@ class Foo
     public function returnWillChange($param, $otherParam)
     {
     }
+
+    /**
+     * Some sentence.
+     *
+     * @param int $param Some Param.
+     * @param bool $otherParam Some Other Param.
+     * @return string Something.
+     */
+    #[ReturnTypeWillChange]
+    #[NoDiscard]
+    public function withMultipleAttributes($param, $otherParam)
+    {
+    }
 }


### PR DESCRIPTION
A minor change to 4.x to prevent a `Commenting.FunctionComment.Missing` error when a function has multiple attribute lines.