### PR TITLE
Update php_codesniffer version to 4.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^1.1.2",
         "phpstan/phpdoc-parser": "^2.1",
         "slevomat/coding-standard": "^8.23",
-        "squizlabs/php_codesniffer": "^4.0"
+        "squizlabs/php_codesniffer": "^4.0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5.32 || ^11.3.3"


### PR DESCRIPTION
I believe this is necessary because of this "high" severity warning: 

https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq

This affects versions `>= 4.0.0, < 4.0.2`.